### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/app/scripts/initialize.py
+++ b/app/scripts/initialize.py
@@ -12,7 +12,7 @@ site_domain = os.environ.get('SITE_DOMAIN', 'localhost:8000')
 if not User.objects.filter(username=username).exists():
     print('CREATING DJANGO SUPERUSER')
     print(f'Username: {username}')
-    print(f'Password: {password}')
+    print('Password: [REDACTED]')
     print(f'Email: {email}')
     user = User.objects.create_user(username, email, password,
                                     is_superuser=1, is_staff=1)
@@ -21,6 +21,7 @@ if not User.objects.filter(username=username).exists():
 else:
     print('DJANGO SUPERUSER ALREADY EXISTS')
     print(f'Username: {username}')
+    print('Password: [REDACTED]')
 
 site = Site.objects.get(id=1)
 if not (site.name == site_name and site.domain == site_domain):


### PR DESCRIPTION
Fixes [https://github.com/nmkpaleo/nmk-cms/security/code-scanning/1](https://github.com/nmkpaleo/nmk-cms/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information such as passwords. Instead, we can log a placeholder or a message indicating that the password has been set without revealing its value. This change will ensure that sensitive data is not exposed in the logs while maintaining the functionality of the script.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
