### PR TITLE
Fix localitys typo

### DIFF
--- a/app/cms/templates/cms/locality_list.html
+++ b/app/cms/templates/cms/locality_list.html
@@ -32,7 +32,7 @@
                     
 
      
-                {% for locality in localitys %}
+                {% for locality in localities %}
 
                    <tr class="template_data">
 

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -335,7 +335,7 @@ class ReferenceListView(ListView):
 class LocalityListView(ListView):
     model = Locality
     template_name = 'cms/locality_list.html'
-    context_object_name = 'localitys'
+    context_object_name = 'localities'
     paginate_by = 10
 
 class LocalityDetailView(DetailView):


### PR DESCRIPTION
## Summary
- rename `localitys` to `localities`
- update template loop to use the corrected name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa2d10d988329be1c64ef40d6f977