### PR TITLE
Fix ValueError string formatting

### DIFF
--- a/app/cms/utils.py
+++ b/app/cms/utils.py
@@ -5,7 +5,7 @@ def generate_accessions_from_series(series_user, count, collection, specimen_pre
     try:
         series = AccessionNumberSeries.objects.get(user=series_user, is_active=True)
     except AccessionNumberSeries.DoesNotExist:
-        raise ValueError("No active accession number series found for user {series_user.username}.")
+        raise ValueError(f"No active accession number series found for user {series_user.username}.")
 
     start = series.current_number
     end = start + count - 1


### PR DESCRIPTION
## Summary
- use an f-string when reporting missing accession number series

## Testing
- `python app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685aa3f305c483299ce9983b2c7059a7