### PR TITLE
Fix media format help text

### DIFF
--- a/app/cms/migrations/0041_alter_media_format_helptext.py
+++ b/app/cms/migrations/0041_alter_media_format_helptext.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('cms', '0040_accessionnumberseries_created_by_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='media',
+            name='format',
+            field=models.CharField(
+                max_length=50,
+                null=True,
+                blank=True,
+                choices=[('jpg', 'JPG'), ('jpeg', 'JPEG'), ('png', 'PNG'), ('gif', 'GIF'), ('bmp', 'BMP')],
+                help_text="File format of the media (supported formats: 'jpg', 'jpeg', 'png', 'gif', 'bmp')",
+            ),
+        ),
+    ]
+

--- a/app/cms/models.py
+++ b/app/cms/models.py
@@ -661,7 +661,13 @@ class Media(BaseModel):
     accession_row = models.ForeignKey('AccessionRow', null=True, blank=True, on_delete=models.CASCADE, related_name='media', help_text="Accession row this media belongs to")    
     file_name = models.CharField(max_length=255, null=True, blank=True, help_text="The name of the media file")
     type = models.CharField(max_length=50, null=True, blank=True, choices=MEDIA_TYPE_CHOICES, help_text="Type of the media (e.g., photo, video, etc.)")
-    format = models.CharField(max_length=50, null=True, blank=True, choices=MEDIA_FORMAT_CHOICES, help_text="File format of the media (valid_formats are 'jpg', 'jpeg', 'png', 'gif', 'tiff' and 'bmp'")
+    format = models.CharField(
+        max_length=50,
+        null=True,
+        blank=True,
+        choices=MEDIA_FORMAT_CHOICES,
+        help_text="File format of the media (supported formats: 'jpg', 'jpeg', 'png', 'gif', 'bmp')"
+    )
     media_location = models.ImageField(upload_to='media/')
     license = models.CharField(max_length=30, choices=LICENSE_CHOICES
                                ,default='CC0'  # Default to public domain


### PR DESCRIPTION
## Summary
- update help text for `Media.format`
- add migration to sync help text

## Testing
- `python app/manage.py makemigrations` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685aa4ce6fe48329a48e1e850868e944