### PR TITLE
Add tests for accession series utility

### DIFF
--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -1,3 +1,78 @@
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-# Create your tests here.
+from cms.models import (
+    Accession,
+    AccessionNumberSeries,
+    Collection,
+    Locality,
+)
+from cms.utils import generate_accessions_from_series
+
+
+class GenerateAccessionsFromSeriesTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+
+        self.series_user = User.objects.create_user(
+            username="series_user", password="pass"
+        )
+        self.creator = User.objects.create_user(
+            username="creator", password="pass"
+        )
+
+        # Patch get_current_user used in BaseModel to bypass authentication
+        self.patcher = patch("cms.models.get_current_user", return_value=self.creator)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+        self.collection = Collection.objects.create(
+            abbreviation="COL", description="Test Collection"
+        )
+        self.locality = Locality.objects.create(abbreviation="LC", name="Locality")
+        self.series = AccessionNumberSeries.objects.create(
+            user=self.series_user,
+            start_from=1,
+            end_at=10,
+            current_number=1,
+            is_active=True,
+        )
+
+    def test_generate_accessions_creates_records_and_increments_series(self):
+        accessions = generate_accessions_from_series(
+            self.series_user,
+            count=3,
+            collection=self.collection,
+            specimen_prefix=self.locality,
+            creator_user=self.creator,
+        )
+
+        self.series.refresh_from_db()
+        self.assertEqual(self.series.current_number, 4)
+        self.assertEqual(Accession.objects.count(), 3)
+        numbers = list(Accession.objects.values_list("specimen_no", flat=True))
+        self.assertEqual(numbers, [1, 2, 3])
+
+        for acc in accessions:
+            self.assertEqual(acc.collection, self.collection)
+            self.assertEqual(acc.specimen_prefix, self.locality)
+            self.assertEqual(acc.accessioned_by, self.series_user)
+
+    def test_generate_accessions_raises_without_active_series(self):
+        self.series.is_active = False
+        self.series.save()
+
+        with self.assertRaisesMessage(
+            ValueError,
+            f"No active accession number series found for user {self.series_user.username}.",
+        ):
+            generate_accessions_from_series(
+                self.series_user,
+                count=1,
+                collection=self.collection,
+                specimen_prefix=self.locality,
+                creator_user=self.creator,
+            )
+


### PR DESCRIPTION
## Summary
- cover generate_accessions_from_series utility with tests

## Testing
- `python app/manage.py test cms.tests.GenerateAccessionsFromSeriesTests --settings=config.settings` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685aa6aa2f7083298552cb1237cfc7a5