### PR TITLE
Implement filtering and permissions on localities

### DIFF
--- a/app/cms/filters.py
+++ b/app/cms/filters.py
@@ -148,3 +148,15 @@ class FieldSlipFilter(django_filters.FilterSet):
             'verbatim_element',
             'verbatim_horizon',
         ]
+
+
+class LocalityFilter(django_filters.FilterSet):
+    name = django_filters.CharFilter(
+        lookup_expr="icontains",
+        label="Name",
+        widget=forms.TextInput(attrs={"class": "w3-input"})
+    )
+
+    class Meta:
+        model = Locality
+        fields = ["name"]

--- a/app/cms/templates/cms/locality_detail.html
+++ b/app/cms/templates/cms/locality_detail.html
@@ -1,4 +1,5 @@
 {% extends "base_generic.html" %}
+{% load user_tags %}
 
 {% block content %}
     
@@ -6,9 +7,11 @@
         <div class="template-detail-container">
             <div class="template-detail-header">
                 <h2 class="template-detail-h2">Locality Detail {{ locality.accession_set.count }} </h2>
+                {% if user.is_superuser or user|has_group:"Collection Managers" %}
                 <a href="{% url 'locality-edit' locality.pk %}" class="edit-icon">
                     Edit Form ✏️
                 </a>
+                {% endif %}
             </div>
             <div class="grid-container">
                 <!-- Field Number Card -->

--- a/app/cms/templates/cms/locality_list.html
+++ b/app/cms/templates/cms/locality_list.html
@@ -1,4 +1,5 @@
 {% extends "base_generic.html" %}
+{% load user_tags %}
 
 {% block title %}
       <title>locality-list</title>
@@ -6,23 +7,43 @@
 
 {% block content %}
 
-    <div class="template_list_body">
-        <div class="container"></div>
-        
-      
-        
+    <div class="w3-container w3-margin-top">
+        <h2>Localities</h2>
+
+        <button onclick="toggleAccordion('localityFilterPanel')" class="w3-button w3-block w3-light-grey w3-left-align">
+          🔍 Show/Hide Filters
+        </button>
+
+        <div id="localityFilterPanel" class="w3-hide w3-animate-opacity w3-padding w3-light-grey w3-round-large w3-margin-top">
+          <form method="get">
+            <div class="w3-row-padding">
+              <div class="w3-third">
+                <label>Name</label>
+                {{ filter.form.name }}
+              </div>
+            </div>
+
+            <div class="w3-container w3-padding-16">
+              <button type="submit" class="w3-button w3-blue w3-margin-right">Apply Filters</button>
+              <a href="{% url 'locality-list' %}" class="w3-button w3-gray">Clear</a>
+            </div>
+          </form>
         </div>
+    </div>
 
-        <div class="table-container">
-            <table class="lists_table">
+          <div class="table-container">
+              <table class="lists_table">
 
 
-                  <th>Abbreviation</th>
-                  <th>Name</b>
+                    <th>Abbreviation</th>
+                    <th>Name</b>
+                    {% if user.is_superuser or user|has_group:"Collection Managers" %}
+                    <th>Edit Locality</th>
+                    {% endif %}
                     
 
      
-                {% for locality in localities %}
+                 {% for locality in localities %}
 
                    <tr class="template_data">
 
@@ -31,9 +52,11 @@
                         
                         <td>{{ locality.name }}</td>
 
+                        {% if user.is_superuser or user|has_group:"Collection Managers" %}
                         <td>
                             <a href="{% url 'locality-edit' locality.pk %}" class="edit-icon">✏️</a>
                         </td>
+                        {% endif %}
 
                     </tr>
   
@@ -46,3 +69,19 @@
     </div>
 
 {% endblock %}
+
+{% block script %}
+<script>
+  function toggleAccordion(id) {
+    var panel = document.getElementById(id);
+    if (panel.classList.contains("w3-show")) {
+      panel.classList.remove("w3-show");
+      panel.classList.add("w3-hide");
+    } else {
+      panel.classList.remove("w3-hide");
+      panel.classList.add("w3-show");
+    }
+  }
+</script>
+{% endblock %}
+

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -6,7 +6,7 @@ from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 from django_filters.views import FilterView
-from .filters import AccessionFilter, PreparationFilter, ReferenceFilter, FieldSlipFilter
+from .filters import AccessionFilter, PreparationFilter, ReferenceFilter, FieldSlipFilter, LocalityFilter
 
 from django.views.generic import DetailView
 from django.core.paginator import Paginator
@@ -337,12 +337,12 @@ class ReferenceListView(FilterView):
     filterset_class = ReferenceFilter
 
 
-class LocalityListView(ListView):
+class LocalityListView(FilterView):
     model = Locality
     template_name = 'cms/locality_list.html'
-
     context_object_name = 'localities'
     paginate_by = 10
+    filterset_class = LocalityFilter
 
 
 class LocalityDetailView(DetailView):


### PR DESCRIPTION
## Summary
- enable filtering Localities by name
- restrict Locality editing links to admins and Collection Managers only

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685bd9e1b108832984b1d1c33c19f1b6