### PR TITLE
Adjust accession templates for normal users

### DIFF
--- a/app/cms/templates/cms/accession_detail.html
+++ b/app/cms/templates/cms/accession_detail.html
@@ -30,10 +30,12 @@
                             <th>Type specimen:</th>
                             <td>{{ accession.type_status }}</td>
                         </tr>
+                        {% if user.is_superuser or user|has_group:"Collection Managers" %}
                         <tr>
                             <th>Accessioned by:</th>
                             <td>{{ accession.accessioned_by }}</td>
                         </tr>
+                        {% endif %}
                         <tr>
                             <th>General comment:</th>
                             <td>{{ accession.comment }}</td>
@@ -224,8 +226,9 @@
                     <p>No Comments found for this accession.</p>
                 {% endif %}            
             </div>
+            {% if user.is_superuser or user|has_group:"Collection Managers" %}
             <div class="cards">
-                
+
                 <table class="table">
                     <caption><b><u>Related FieldSlips</u></b></caption>
                     <thead>
@@ -280,8 +283,9 @@
                             <button onclick="closeFieldSlipModal()" class="w3-button w3-red">Cancel</button>
                         </footer>
                     </div>
-                </div>           
+                </div>
             </div>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/app/cms/templates/cms/accession_list.html
+++ b/app/cms/templates/cms/accession_list.html
@@ -47,8 +47,8 @@
                 <th>Collection</th>
                 <th>Specimen Prefix</th>
                 <th>Specimen Number</th>
-                <th>accessioned By</th>
                 {% if user.is_superuser or user|has_group:"Collection Managers" %}
+                <th>accessioned By</th>
                 <th>Edit Accession</th>
                 {% endif %}
             </thead>
@@ -59,8 +59,8 @@
                         <td> <a href="{% url 'accession_detail' accession.pk %}"> {{ accession.collection.abbreviation }}</a></td>
                         <td>&nbsp;{{ accession.specimen_prefix.abbreviation }}</td>
                         <td>{{ accession.specimen_no }}</td>
-                        <td>&nbsp;{{ accession.accessioned_by }}</td>
                         {% if user.is_superuser or user|has_group:"Collection Managers" %}
+                        <td>&nbsp;{{ accession.accessioned_by }}</td>
                         <td><a href="{% url 'accession_edit' accession.pk %}" class="edit-icon">✏️</a></td>
                         {% endif %}
                     </tr>

--- a/app/cms/templates/cms/locality_detail.html
+++ b/app/cms/templates/cms/locality_detail.html
@@ -32,33 +32,23 @@
                             <tr>
                                 <th><u>Collection</u></th>
                                 <th><u>Specimen  Number</u></th>
+                                {% if user.is_superuser or user|has_group:"Collection Managers" %}
                                 <th><u>Accesioned by</u></th>
-                                
+                                {% endif %}
                             </tr>
-                                      
-                                <tr>
-                                    
-                                    {% for accession in accessions %}
-                                        <tr >
-                                            <td>{{ accession.collection.abbreviation }}</td>
-                                            
-          <td><a href="{% url 'accession_detail' accession.pk %}">{{ accession.specimen_no }}</a></td>
-                                            <td>&nbsp;{{ accession.accessioned_by }}</td>
-                                        </tr>
-                                    {% endfor %}
-                                       
-
-
-
-
-                        </tbody>
-
-
                         </thead>
                         <tbody>
-                            
-                            <tr><th></th></tr>
-                    </table>                
+                            {% for accession in accessions %}
+                            <tr>
+                                <td>{{ accession.collection.abbreviation }}</td>
+                                <td><a href="{% url 'accession_detail' accession.pk %}">{{ accession.specimen_no }}</a></td>
+                                {% if user.is_superuser or user|has_group:"Collection Managers" %}
+                                <td>&nbsp;{{ accession.accessioned_by }}</td>
+                                {% endif %}
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                     <hr class="accession_hr">
                     <div class="pagination">
 


### PR DESCRIPTION
## Summary
- hide `Accessioned by` from detail page for normal users
- hide related FieldSlips section for normal users
- hide `accessioned By` column on accession list for normal users
- restrict `Accesioned by` on locality detail page as well

## Testing
- `python app/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685d401017248329979b1286f80e656e