### PR TITLE
Fix locality list clear button URL

### DIFF
--- a/app/cms/templates/cms/locality_list.html
+++ b/app/cms/templates/cms/locality_list.html
@@ -58,7 +58,7 @@
 
     <div class="w3-container w3-padding-16">
         <button type="submit" class="w3-button w3-blue w3-margin-right">Apply Filters</button>
-        <a href="{% url 'locality-list' %}" class="w3-button w3-gray">Clear</a>
+        <a href="{% url 'locality_list' %}" class="w3-button w3-gray">Clear</a>
     </div>
 </form>
 


### PR DESCRIPTION
## Summary
- Fix locality list template to use correct `locality_list` URL name

## Testing
- `pytest -q`
- `python manage.py test` *(fails: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_689332f86b448329959a3ff7c9bca289