### PR TITLE
Add import/export to PreparationMaterial admin

### DIFF
--- a/app/cms/admin.py
+++ b/app/cms/admin.py
@@ -417,7 +417,8 @@ class PreparationAdmin(admin.ModelAdmin):
     admin_status_info.short_description = "Status Overview"
 
 @admin.register(PreparationMaterial)
-class PreparationMaterialAdmin(admin.ModelAdmin):
+class PreparationMaterialAdmin(ImportExportModelAdmin):
+    resource_class = PreparationMaterialResource
     list_display = ("name", "description")
     search_fields = ("name",)
 

--- a/app/cms/resources.py
+++ b/app/cms/resources.py
@@ -1,5 +1,5 @@
 from venv import logger
-from .models import Accession, AccessionReference, AccessionRow, Collection, Element, FieldSlip, GeologicalContext, Identification, Locality, Media, NatureOfSpecimen, Person, Reference, SpecimenGeology, Storage, Taxon, User
+from .models import Accession, AccessionReference, AccessionRow, Collection, Element, FieldSlip, GeologicalContext, Identification, Locality, Media, NatureOfSpecimen, Person, PreparationMaterial, Reference, SpecimenGeology, Storage, Taxon, User
 from import_export import resources, fields
 #from import_export.fields import Field
 from import_export.widgets import BooleanWidget, ForeignKeyWidget, DateWidget
@@ -526,6 +526,15 @@ class PersonResource(resources.ModelResource):
         import_id_fields = ('first_name', 'last_name',)
         fields = ('first_name', 'last_name', 'orcid')
         export_order = ('first_name', 'last_name', 'orcid')
+
+class PreparationMaterialResource(resources.ModelResource):
+    class Meta:
+        model = PreparationMaterial
+        skip_unchanged = True
+        report_skipped = False
+        import_id_fields = ('name',)
+        fields = ('name', 'description')
+        export_order = ('name', 'description')
 
 class ReferenceResource(resources.ModelResource):
     class Meta:


### PR DESCRIPTION
## Summary
- allow preparation materials to be imported and exported via the admin

## Testing
- `python app/manage.py test` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68935ea2bd788329bc9ec620753e95f6