### PR TITLE
Enable import/export on Preparation admin

### DIFF
--- a/app/cms/admin.py
+++ b/app/cms/admin.py
@@ -355,9 +355,10 @@ class PreparationMediaInline(admin.TabularInline):
 
 
 @admin.register(Preparation)
-class PreparationAdmin(admin.ModelAdmin):
+class PreparationAdmin(ImportExportModelAdmin):
     """ Custom admin panel for Preparation model. """
-    
+
+    resource_class = PreparationResource
     form = PreparationAdminForm
     list_display = ("accession_row", "preparator", "status", "curator", "approval_status", "approval_date", "admin_colored_status")
     list_filter = ("status", "approval_status", "preparator", "curator")


### PR DESCRIPTION
## Summary
- add `PreparationResource` using human-friendly identifiers for related objects
- allow Preparation admin to import/export data

## Testing
- `python manage.py test` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68936501b9c48329a87f6e684fdc4053