### PR TITLE
Add preparator landing page

### DIFF
--- a/app/cms/templates/cms/dashboard.html
+++ b/app/cms/templates/cms/dashboard.html
@@ -1,0 +1,51 @@
+{% extends "base_generic.html" %}
+
+{% block content %}
+  {% if role == "Preparator" %}
+    <h2>My Preparations</h2>
+    {% if my_preparations %}
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Specimen</th>
+            <th>Status</th>
+            <th>Started On</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for prep in my_preparations %}
+            <tr>
+              <td>{{ prep.accession_row }}</td>
+              <td>{{ prep.status }}</td>
+              <td>{{ prep.started_on }}</td>
+              <td>
+                <a href="{% url 'preparation_detail' prep.id %}" class="btn btn-sm btn-info">View</a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>No active preparations assigned.</p>
+    {% endif %}
+
+    <h2>Priority Tasks</h2>
+    {% if priority_tasks %}
+      <ul>
+        {% for task in priority_tasks %}
+          <li>
+            <a href="{% url 'preparation_detail' task.id %}">{{ task.accession_row }}</a>
+            - started on {{ task.started_on }}
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No priority tasks.</p>
+    {% endif %}
+
+    <a href="{% url 'preparation_create' %}" class="btn btn-primary">Create Preparation Record</a>
+  {% else %}
+    <p>Dashboard content for your role is not available yet.</p>
+  {% endif %}
+{% endblock %}

--- a/app/cms/urls.py
+++ b/app/cms/urls.py
@@ -18,7 +18,8 @@ from cms.views import (
     upload_media,
     PreparationListView, PreparationDetailView,
     PreparationCreateView, PreparationUpdateView, PreparationDeleteView,
-    PreparationApproveView
+    PreparationApproveView,
+    dashboard,
 )
 from .views import PreparationMediaUploadView
 from .views import FieldSlipAutocomplete
@@ -86,4 +87,8 @@ urlpatterns += [
 
 urlpatterns += [
     path("autocomplete/fieldslip/", FieldSlipAutocomplete.as_view(), name="fieldslip-autocomplete"),
+]
+
+urlpatterns += [
+    path("dashboard/", dashboard, name="dashboard"),
 ]


### PR DESCRIPTION
## Summary
- Add dashboard view that surfaces preparator preparations and priority tasks
- Link new dashboard route and template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894bbf2d6dc83299d85ffabbeaf6a66