### PR TITLE
Add inventory session start page

### DIFF
--- a/app/cms/templates/inventory/start.html
+++ b/app/cms/templates/inventory/start.html
@@ -1,0 +1,21 @@
+{% extends "base_generic.html" %}
+
+{% block title %}
+<title>Inventory Session</title>
+{% endblock %}
+
+{% block content %}
+<div class="w3-container w3-margin-top">
+  <h2>Start Inventory Session</h2>
+  <form method="post" class="w3-margin-top">
+    {% csrf_token %}
+    <label for="shelf_ids">Select Shelves</label>
+    <select name="shelf_ids" id="shelf_ids" class="w3-select" multiple>
+      {% for shelf in shelves %}
+        <option value="{{ shelf.id }}">{{ shelf }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit" class="w3-button w3-blue w3-margin-top">Start Session</button>
+  </form>
+</div>
+{% endblock %}

--- a/app/cms/urls.py
+++ b/app/cms/urls.py
@@ -20,6 +20,7 @@ from cms.views import (
     PreparationCreateView, PreparationUpdateView, PreparationDeleteView,
     PreparationApproveView,
     dashboard,
+    inventory_start,
 )
 from .views import PreparationMediaUploadView
 from .views import FieldSlipAutocomplete
@@ -32,7 +33,7 @@ from cms.views import AccessionWizard
 from django_select2.views import AutoResponseView
 
 urlpatterns = [
-    
+    path('inventory/', inventory_start, name='inventory_start'),
     path('fieldslips/new/', fieldslip_create, name='fieldslip_create'),
     path('fieldslips/<int:pk>/', FieldSlipDetailView.as_view(), name='fieldslip_detail'),
     path('fieldslips/<int:pk>/edit/', fieldslip_edit, name='fieldslip_edit'),

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -1008,4 +1008,18 @@ class PreparationMediaUploadView(View):
             "form": form,
             "preparation": preparation,
         })
+
+
+@login_required
+def inventory_start(request):
+    """Initialize an inventory session for selected shelves."""
+    if request.method == "POST":
+        shelf_ids = request.POST.getlist("shelf_ids")
+        if shelf_ids:
+            request.session["inventory_shelf_ids"] = shelf_ids
+            messages.success(request, "Inventory session started.")
+            return redirect("inventory_start")
+
+    shelves = Storage.objects.all()
+    return render(request, "inventory/start.html", {"shelves": shelves})
     


### PR DESCRIPTION
## Summary
- Add inventory session start view storing selected shelf IDs in session
- Create inventory start template with shelf selector and start button
- Wire new view under /inventory/ URL

## Testing
- `python app/manage.py test` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68962db840488329a0069ec19129bdcf