### PR TITLE
feat: add inventory session tracking

### DIFF
--- a/app/cms/templates/inventory/session.html
+++ b/app/cms/templates/inventory/session.html
@@ -1,0 +1,51 @@
+{% extends "base_generic.html" %}
+{% load custom_filters %}
+
+{% block title %}<title>Inventory Session</title>{% endblock %}
+
+{% block content %}
+<div class="w3-container w3-margin-top">
+  <h2>Inventory Session</h2>
+  {% csrf_token %}
+  <table class="w3-table-all">
+    <thead>
+      <tr>
+        <th>Accession</th>
+        <th>Specimen</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for specimen in specimens %}
+      <tr data-id="{{ specimen.id }}">
+        <td>{{ specimen.accession }}</td>
+        <td>{{ specimen.specimen_suffix }}</td>
+        <td>
+          <select class="status-select">
+            {% for key,label in status_choices %}
+            <option value="{{ key }}" {% if statuses|get_item:specimen.id == key %}selected{% endif %}>{{ label }}</option>
+            {% endfor %}
+          </select>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<script>
+const csrftoken = '{{ csrf_token }}';
+document.querySelectorAll('.status-select').forEach(function(select){
+  select.addEventListener('change', function(){
+    const id = this.closest('tr').dataset.id;
+    fetch('{% url "inventory_update" %}', {
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': csrftoken,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({specimen_id: id, status: this.value})
+    });
+  });
+});
+</script>
+{% endblock %}

--- a/app/cms/urls.py
+++ b/app/cms/urls.py
@@ -20,7 +20,7 @@ from cms.views import (
     PreparationCreateView, PreparationUpdateView, PreparationDeleteView,
     PreparationApproveView,
     dashboard,
-    inventory_start,
+    inventory_start, inventory_update,
 )
 from .views import PreparationMediaUploadView
 from .views import FieldSlipAutocomplete
@@ -34,6 +34,7 @@ from django_select2.views import AutoResponseView
 
 urlpatterns = [
     path('inventory/', inventory_start, name='inventory_start'),
+    path('inventory/update/', inventory_update, name='inventory_update'),
     path('fieldslips/new/', fieldslip_create, name='fieldslip_create'),
     path('fieldslips/<int:pk>/', FieldSlipDetailView.as_view(), name='fieldslip_detail'),
     path('fieldslips/<int:pk>/edit/', fieldslip_edit, name='fieldslip_edit'),


### PR DESCRIPTION
## Summary
- show expected specimens for selected shelves in inventory session
- allow marking specimen statuses via dropdown
- add AJAX endpoint to persist specimen status selections

## Testing
- `python app/manage.py test` *(fails: TypeError: can only concatenate str (not "NoneType") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68963179fae08329a62e482d480655a3