### PR TITLE
Fix navigation bar overflow

### DIFF
--- a/app/cms/static/css/style.css
+++ b/app/cms/static/css/style.css
@@ -29,8 +29,8 @@
 
 .sidebar-nav{
     display: flex;
-    gap: 60px;
-    
+    gap: 30px;
+    flex-wrap: wrap;
     margin-top: 20px;
     padding-bottom: 15px;
     font-size: 20px;
@@ -43,10 +43,28 @@
 .sidebar-nav li a{
     text-decoration: none;
     color: #232323;
-    font-family: 'Inter', sans-serif
+    font-family: 'Inter', sans-serif;
 }
 
 .sidebar-nav li a:hover{
+    color: #C46132;
+    text-decoration: underline;
+}
+
+.logout-form {
+    display: inline;
+}
+
+.logout-form .logout-button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: #232323;
+    font-family: 'Inter', sans-serif;
+    cursor: pointer;
+}
+
+.logout-form .logout-button:hover {
     color: #C46132;
     text-decoration: underline;
 }

--- a/app/cms/templates/base_generic.html
+++ b/app/cms/templates/base_generic.html
@@ -63,9 +63,9 @@
               {% if user.is_authenticated %}
                 <li>User: {{ user.get_username }}</li>
                 <li>
-                  <form id="logout-form" method="post" action="{% url 'account_logout' %}">
+                  <form id="logout-form" class="logout-form" method="post" action="{% url 'account_logout' %}">
                     {% csrf_token %}
-                    <button type="submit" class="btn btn-link">Logout</button>
+                    <button type="submit" class="logout-button">Logout</button>
                   </form>
                 </li>
               {% else %}


### PR DESCRIPTION
## Summary
- prevent top navigation from overflowing by reducing spacing and allowing wrapping
- style logout button and form to appear inline like other nav items

## Testing
- `python app/manage.py test` *(fails: TypeError: can only concatenate str (not "PosixPath") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a8e1c54483299c0966c9256f5853