### PR TITLE
docs: add guides for localities, references, preparations

### DIFF
--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,3 +1,6 @@
 # Admin Guides
 
 - [Drawer Register](drawer-register.md)
+- [Localities](localities.md)
+- [References](references.md)
+- [Preparations](preparations.md)

--- a/docs/admin/localities.md
+++ b/docs/admin/localities.md
@@ -1,0 +1,19 @@
+# Localities (Admin)
+
+Administrators can manage locality codes through the Django admin interface.
+
+## Adding or Editing a Locality
+1. Log in to the admin site.
+2. Select **Localities** from the sidebar.
+3. Use **Add Locality** to create a new entry or choose an existing one to edit.
+4. Enter the two-letter abbreviation and the locality name.
+5. Save the entry. Changes are recorded in the log.
+
+## Importing and Exporting
+1. From the **Localities** changelist, use **Import** or **Export** for bulk operations.
+2. CSV files list the abbreviation and name columns.
+3. After uploading, review the preview and confirm to apply the changes.
+
+## Viewing Change Logs
+1. In the admin list, select a locality.
+2. Scroll to the history section to see past edits.

--- a/docs/admin/preparations.md
+++ b/docs/admin/preparations.md
@@ -1,0 +1,19 @@
+# Preparations (Admin)
+
+Administrators can track specimen preparation records in the admin site.
+
+## Adding or Editing a Preparation
+1. Log in to the admin site.
+2. Select **Preparations** from the sidebar.
+3. Use **Add Preparation** to create a record or choose one to edit.
+4. Specify the specimen, preparator, preparation type, status and relevant dates.
+5. Save the entry. Validation ensures curator and preparator are different and approval follows completion.
+
+## Importing and Exporting
+1. From the **Preparations** changelist, use **Import** and **Export** for bulk operations.
+2. CSV files include preparation fields such as status and dates.
+3. After uploading, review the preview and confirm to apply the changes.
+
+## Viewing Logs
+1. In the admin list, select a preparation.
+2. Scroll to the **Preparation Logs** section to review recorded changes.

--- a/docs/admin/references.md
+++ b/docs/admin/references.md
@@ -1,0 +1,19 @@
+# References (Admin)
+
+Administrators can manage bibliographic references through the Django admin interface.
+
+## Adding or Editing a Reference
+1. Log in to the admin site.
+2. Select **References** from the sidebar.
+3. Use **Add Reference** or select an existing entry to edit.
+4. Provide the title, first author, year and any optional fields.
+5. Save the entry.
+
+## Importing and Exporting
+1. From the **References** changelist, use **Import** and **Export** for bulk operations.
+2. CSV files include citation details such as title, author and year.
+3. After uploading, review the preview and confirm to apply the changes.
+
+## Viewing Change Logs
+1. In the admin list, select a reference.
+2. Scroll to the history section for edit records.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,3 +1,6 @@
 # User Guides
 
 - [Drawer Register](drawer-register.md)
+- [Localities](localities.md)
+- [References](references.md)
+- [Preparations](preparations.md)

--- a/docs/user/localities.md
+++ b/docs/user/localities.md
@@ -1,0 +1,15 @@
+# Localities (User)
+
+Collection managers can review and update locality information within the CMS.
+
+## Accessing Localities
+1. Log in to the CMS.
+2. Use the navigation menu to open **Localities**.
+
+## Filtering and Reviewing
+- Use the filter panel to search by abbreviation or name.
+- Click a locality abbreviation to view details.
+
+## Editing a Locality
+- Select the edit icon on a locality to update the abbreviation or name.
+- Save your changes. New localities must be added by an administrator.

--- a/docs/user/preparations.md
+++ b/docs/user/preparations.md
@@ -1,0 +1,17 @@
+# Preparations (User)
+
+Curators and preparators can document specimen preparation work.
+
+## Accessing Preparations
+1. Log in to the CMS.
+2. Use the navigation menu to open **Preparations**.
+
+## Creating a Preparation
+1. Click **New Preparation** on the list page.
+2. Select the specimen and enter preparation details such as type, status and dates.
+3. Save the record.
+
+## Updating or Curating
+- Preparators can open their preparations to edit details or delete the record.
+- Curators can open a preparation and use the **Curate** action to approve or decline it.
+- Use the filter panel to search by specimen, status, approval or preparator.

--- a/docs/user/references.md
+++ b/docs/user/references.md
@@ -1,0 +1,17 @@
+# References (User)
+
+Collection managers can record publications related to specimens.
+
+## Accessing References
+1. Log in to the CMS.
+2. Use the navigation menu to open **References**.
+
+## Creating a Reference
+1. Click **New Reference** on the list page.
+2. Enter the title, first author, year and any additional citation details.
+3. Save the reference.
+
+## Editing or Reviewing
+- Click the first author to view the reference.
+- Use the edit icon to update information when needed.
+- Filter by author, year or title using the filter panel.


### PR DESCRIPTION
## Summary
- add admin guides for Localities, References, and Preparations
- document Localities, References, and Preparations usage for CMS users
- link new guides from admin and user documentation indexes

## Testing
- `python app/manage.py test` *(fails: can only concatenate str (not "PosixPath") to str)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ad14e9088329896a9059ed4a0eb2