### PR TITLE
Refactor history display and enhance drawer change log

### DIFF
--- a/app/cms/templates/cms/drawerregister_detail.html
+++ b/app/cms/templates/cms/drawerregister_detail.html
@@ -8,17 +8,42 @@
   <p><strong>Status:</strong> {{ object.get_scanning_status_display }}</p>
   <p><strong>Scanning users:</strong> {{ object.scanning_users.all|join:", " }}</p>
   <h3>Change Log</h3>
-  <ul>
-    {% for entry in history_entries %}
-      <li>
-        {{ entry.log.history_date|date:"Y-m-d H:i" }} - {{ entry.log.get_history_type_display }}
-        {% if entry.changes %} ({{ entry.changes|join:"; " }}){% endif %}
-        {% if entry.log.history_user %} by {{ entry.log.history_user }}{% endif %}
-      </li>
-    {% empty %}
-      <li>No changes logged.</li>
-    {% endfor %}
-  </ul>
+  {% if history_entries %}
+    <table class="table table-striped">
+      <thead>
+        <tr>
+          <th>Date/time</th>
+          <th></th>
+          <th>Comment</th>
+          <th>Changed by</th>
+          <th>Changes</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in history_entries %}
+          <tr>
+            <td>{{ entry.log.history_date|date:"Y-m-d H:i" }}</td>
+            <td>{{ entry.log.history_type }}</td>
+            <td>{{ entry.log.history_change_reason|default:"" }}</td>
+            <td>{{ entry.log.history_user|default:"System or Unknown" }}</td>
+            <td>
+              {% if entry.changes %}
+                <ul>
+                  {% for change in entry.changes %}
+                    <li><strong>{{ change.field }}:</strong> {{ change.old }} → {{ change.new }}</li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                Initial version
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p>No changes logged.</p>
+  {% endif %}
   <a href="{% url 'drawerregister_edit' object.pk %}" class="w3-button w3-blue">Edit</a>
 </div>
 {% endblock %}

--- a/app/cms/utils.py
+++ b/app/cms/utils.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from django.db import models
 from cms.models import Accession, AccessionNumberSeries
 
 def generate_accessions_from_series(series_user, count, collection, specimen_prefix, creator_user=None):
@@ -37,3 +38,41 @@ def generate_accessions_from_series(series_user, count, collection, specimen_pre
 
 def get_active_series_for_user(user):
     return AccessionNumberSeries.objects.filter(user=user, is_active=True).first()
+
+
+def build_history_entries(instance):
+    """Return structured change history entries for a model instance.
+
+    Each entry contains the historical log record and a list of field-level
+    changes with verbose field names and resolved foreign-key references.
+    """
+    model = type(instance)
+    history_entries = []
+    for log in instance.history.all().order_by("-history_date", "-history_id"):
+        prev = log.prev_record
+        changes = []
+        if prev:
+            delta = log.diff_against(prev)
+            for change in delta.changes:
+                field = model._meta.get_field(change.field)
+                field_name = field.verbose_name.capitalize()
+                old = change.old
+                new = change.new
+                if isinstance(field, models.ForeignKey):
+                    related_model = field.remote_field.model
+                    old_obj = related_model.objects.filter(pk=old).first()
+                    new_obj = related_model.objects.filter(pk=new).first()
+                    old = str(old_obj) if old_obj else old
+                    new = str(new_obj) if new_obj else new
+                elif isinstance(field, models.ManyToManyField):
+                    related_model = field.remote_field.model
+                    old_ids = set(old or [])
+                    new_ids = set(new or [])
+                    old_objs = related_model.objects.filter(pk__in=old_ids)
+                    new_objs = related_model.objects.filter(pk__in=new_ids)
+                    old = ", ".join(str(obj) for obj in old_objs)
+                    new = ", ".join(str(obj) for obj in new_objs)
+                changes.append({"field": field_name, "old": old, "new": new})
+        history_entries.append({"log": log, "changes": changes})
+    return history_entries
+


### PR DESCRIPTION
## Summary
- centralize change history processing with `build_history_entries`
- reuse helper in preparation and drawer detail views
- render drawer change log as bulleted field-by-field table

## Testing
- `python app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bec6a29cb0832987800d4f9a480977