### PR TITLE
Add SQLite fallback for database connection

### DIFF
--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -943,6 +943,13 @@ class PlaceModelTests(TestCase):
 
 class PlaceViewTests(TestCase):
     def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="viewer", password="pass")
+
+        self.patcher = patch("cms.models.get_current_user", return_value=self.user)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
         self.locality = Locality.objects.create(abbreviation="LC", name="Locality")
         self.place = Place.objects.create(
             locality=self.locality,
@@ -982,6 +989,13 @@ class PlaceViewTests(TestCase):
 
 class PlaceImportTests(TestCase):
     def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username="importer", password="pass")
+
+        self.patcher = patch("cms.models.get_current_user", return_value=self.user)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
         self.locality = Locality.objects.create(abbreviation="LC", name="Locality")
         self.resource = PlaceResource()
 

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 """
 
 import os
+import sys
 import json
 
 from pathlib import Path
@@ -155,6 +156,19 @@ DATABASES = {
         },
     }
 }
+
+from django.db.utils import OperationalError, ConnectionHandler
+
+if "test" in sys.argv:
+    connections = ConnectionHandler(DATABASES)
+    try:
+        connections["default"].ensure_connection()
+    except OperationalError:
+        DATABASES["default"] = {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": BASE_DIR / "db.sqlite3",
+        }
+        connections = ConnectionHandler(DATABASES)
 
 if DATABASES["default"]["ENGINE"] == "django.db.backends.sqlite3":
     DATABASES["default"].pop("OPTIONS", None)


### PR DESCRIPTION
## Summary
- ensure database connectivity on startup and switch to SQLite if the configured backend is unavailable
- patch tests to mock authenticated users so base model validation passes
- fall back to SQLite only when running tests to avoid masking production misconfiguration

## Testing
- `python app/manage.py migrate` (fails: Can't connect to local MySQL server)
- `python app/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68bee8dd158c8329b902e43c12a96f3a