### PR TITLE
Fix Drawer Register drag-and-drop priority

### DIFF
--- a/app/cms/models.py
+++ b/app/cms/models.py
@@ -1170,7 +1170,9 @@ class DrawerRegister(BaseModel):
     class Meta:
         verbose_name = "Drawer Register"
         verbose_name_plural = "Drawer Register"
-        ordering = ["priority", "code"]
+        # Display entries with higher priority first; items without an
+        # explicit priority (default ``0``) appear last.
+        ordering = ["-priority", "code"]
 
     def clean(self):
         super().clean()

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -1260,7 +1260,9 @@ class DrawerRegisterReorderView(LoginRequiredMixin, DrawerRegisterAccessMixin, V
     def post(self, request, *args, **kwargs):
         data = json.loads(request.body)
         order = data.get("order", [])
-        for priority, pk in enumerate(order, start=1):
+        # Assign larger priority values to items appearing earlier in the
+        # provided order so they are shown first when ordered descending.
+        for priority, pk in enumerate(reversed(order), start=1):
             DrawerRegister.objects.filter(pk=pk).update(priority=priority)
         return JsonResponse({"status": "ok"})
 


### PR DESCRIPTION
## Summary
- Order Drawer Registers by descending priority so unprioritised drawers fall to the bottom
- Persist drag-and-drop ordering by assigning larger priorities to earlier rows

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe15147f88329bcd10249e032d21f