### PR TITLE
Update media location when OCR processing fails

### DIFF
--- a/app/cms/ocr_processing.py
+++ b/app/cms/ocr_processing.py
@@ -331,7 +331,9 @@ def process_pending_scans(limit: int = 100) -> tuple[int, int, int, list[str]]:
             errors.append(error_msg)
             logger.exception("OCR processing failed for %s", path)
             failed_dir.mkdir(parents=True, exist_ok=True)
-            shutil.move(path, failed_dir / path.name)
+            dest = failed_dir / path.name
+            shutil.move(path, dest)
+            media.media_location.name = str(dest.relative_to(settings.MEDIA_ROOT))
             media.ocr_status = Media.OCRStatus.FAILED
             media.ocr_data = {"error": str(exc)}
             media.save()

--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -1208,6 +1208,7 @@ class ProcessPendingScansTests(TestCase):
         media = Media.objects.get()
         self.assertEqual(media.ocr_status, Media.OCRStatus.FAILED)
         self.assertEqual(media.ocr_data["error"], "boom")
+        self.assertEqual(media.media_location.name, f"uploads/failed/{filename}")
         failed_file = Path(settings.MEDIA_ROOT) / "uploads" / "failed" / filename
         self.assertTrue(failed_file.exists())
 


### PR DESCRIPTION
## Summary
- ensure media record location is updated when OCR processing fails
- test that failed scans update media location correctly

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68c2bbb36fd88329a98dcd4a8bff3063