### PR TITLE
Add user documentation for scanning workflow

### DIFF
--- a/app/cms/admin.py
+++ b/app/cms/admin.py
@@ -165,19 +165,19 @@ class AccessionNumberSeriesAdmin(HistoricalAdmin):
         formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
 
         if db_field.name == "user":
-            # Compute shared vs Mary series
+            # Compute shared vs TBI series
             from django.contrib.auth import get_user_model
             User = get_user_model()
 
         try:
-            mary_series = AccessionNumberSeries.objects.filter(user__username__iexact="mary")
-            shared_series = AccessionNumberSeries.objects.exclude(user__username__iexact="mary")
+            tbi_series = AccessionNumberSeries.objects.filter(user__username__iexact="tbi")
+            shared_series = AccessionNumberSeries.objects.exclude(user__username__iexact="tbi")
 
-            mary_end = mary_series.order_by('-end_at').first()
+            tbi_end = tbi_series.order_by('-end_at').first()
             shared_end = shared_series.order_by('-end_at').first()
 
             series_map = {
-                "mary": mary_end.end_at + 1 if mary_end and mary_end.end_at else 1_000_000,
+                "tbi": tbi_end.end_at + 1 if tbi_end and tbi_end.end_at else 1_000_000,
                 "shared": shared_end.end_at + 1 if shared_end and shared_end.end_at else 1,
             }
 

--- a/app/cms/admin.py
+++ b/app/cms/admin.py
@@ -165,29 +165,19 @@ class AccessionNumberSeriesAdmin(HistoricalAdmin):
         formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
 
         if db_field.name == "user":
-            # Compute shared vs TBI series
-            from django.contrib.auth import get_user_model
-            User = get_user_model()
+            try:
+                series_map = {
+                    "tbi": AccessionNumberSeriesAdminForm._next_start_for_pool(is_tbi_pool=True),
+                    "shared": AccessionNumberSeriesAdminForm._next_start_for_pool(is_tbi_pool=False),
+                }
 
-        try:
-            tbi_series = AccessionNumberSeries.objects.filter(user__username__iexact="tbi")
-            shared_series = AccessionNumberSeries.objects.exclude(user__username__iexact="tbi")
+                if hasattr(formfield.widget, 'attrs'):
+                    formfield.widget.attrs["data-series-starts"] = json.dumps(series_map)
 
-            tbi_end = tbi_series.order_by('-end_at').first()
-            shared_end = shared_series.order_by('-end_at').first()
-
-            series_map = {
-                "tbi": tbi_end.end_at + 1 if tbi_end and tbi_end.end_at else 1_000_000,
-                "shared": shared_end.end_at + 1 if shared_end and shared_end.end_at else 1,
-            }
-
-            if hasattr(formfield.widget, 'attrs'):
-                formfield.widget.attrs["data-series-starts"] = json.dumps(series_map)
-
-        except Exception as e:
-            # Just log the issue, don't block the form rendering or validation
-            import logging
-            logging.warning(f"Series mapping failed: {e}")
+            except Exception as e:
+                # Just log the issue, don't block the form rendering or validation
+                import logging
+                logging.warning(f"Series mapping failed: {e}")
 
         return formfield
 

--- a/app/cms/admin.py
+++ b/app/cms/admin.py
@@ -40,7 +40,6 @@ from .models import (
 )
 from .resources import *
 
-import json
 import logging
 
 from django import forms
@@ -166,13 +165,10 @@ class AccessionNumberSeriesAdmin(HistoricalAdmin):
 
         if db_field.name == "user":
             try:
-                series_map = {
-                    "tbi": AccessionNumberSeriesAdminForm._next_start_for_pool(is_tbi_pool=True),
-                    "shared": AccessionNumberSeriesAdminForm._next_start_for_pool(is_tbi_pool=False),
-                }
-
                 if hasattr(formfield.widget, 'attrs'):
-                    formfield.widget.attrs["data-series-starts"] = json.dumps(series_map)
+                    formfield.widget.attrs.update(
+                        AccessionNumberSeriesAdminForm._widget_metadata()
+                    )
 
             except Exception as e:
                 # Just log the issue, don't block the form rendering or validation

--- a/app/cms/forms.py
+++ b/app/cms/forms.py
@@ -109,11 +109,11 @@ class AccessionNumberSeriesAdminForm(forms.ModelForm):
             
         # Inject JS data for user field
         if 'user' in self.fields:
-            mary_series = AccessionNumberSeries.objects.filter(user__username__iexact='mary').order_by('-end_at').first()
-            shared_series = AccessionNumberSeries.objects.exclude(user__username__iexact='mary').order_by('-end_at').first()
+            tbi_series = AccessionNumberSeries.objects.filter(user__username__iexact='tbi').order_by('-end_at').first()
+            shared_series = AccessionNumberSeries.objects.exclude(user__username__iexact='tbi').order_by('-end_at').first()
 
             series_map = {
-                "mary": mary_series.end_at + 1 if mary_series and mary_series.end_at else 1_000_000,
+                "tbi": tbi_series.end_at + 1 if tbi_series and tbi_series.end_at else 1_000_000,
                 "shared": shared_series.end_at + 1 if shared_series and shared_series.end_at else 1
             }
 
@@ -124,7 +124,7 @@ class AccessionNumberSeriesAdminForm(forms.ModelForm):
         series_map = {}
         for user in User.objects.all():
             qs = AccessionNumberSeries.objects.filter(user=user).order_by('-end_at')
-            base = 1_000_000 if user.username.lower() == 'mary' else 1
+            base = 1_000_000 if user.username.lower() == 'tbi' else 1
 
             if qs.exists() and qs.first().end_at is not None:
                 next_start = qs.first().end_at + 1
@@ -133,7 +133,7 @@ class AccessionNumberSeriesAdminForm(forms.ModelForm):
 
             series_map[user.username.lower()] = next_start
             self.fields['user'].widget.attrs['data-series-starts'] = json.dumps({
-                "mary": 1_000_000,
+                "tbi": 1_000_000,
                 "default": 1
             })
             self.fields['user'].label_from_instance = lambda obj: obj.username

--- a/app/cms/models.py
+++ b/app/cms/models.py
@@ -278,21 +278,21 @@ class AccessionNumberSeries(BaseModel):
         if self.start_from >= self.end_at:
             raise ValidationError("Start number must be less than end number.")
         
-        # Determine if this is Mary or shared user series
-        is_mary = self.user.username.strip().lower() == "mary"
+        # Determine if this is TBI or shared user series
+        is_tbi = self.user.username.strip().lower() == "tbi"
 
         # Build appropriate queryset to check overlaps
-        if is_mary:
-            # Only check overlap among Mary's series
+        if is_tbi:
+            # Only check overlap among TBI's series
             conflicting_series = AccessionNumberSeries.objects.exclude(pk=self.pk).filter(
-                user__username__iexact="mary",
+                user__username__iexact="tbi",
                 start_from__lte=self.end_at,
                 end_at__gte=self.start_from,
             )
         else:
-            # Shared users (everyone except Mary)
+            # Shared users (everyone except TBI)
             conflicting_series = AccessionNumberSeries.objects.exclude(pk=self.pk).exclude(
-                user__username__iexact="mary"
+                user__username__iexact="tbi"
             ).filter(
                 start_from__lte=self.end_at,
                 end_at__gte=self.start_from,

--- a/app/cms/static/js/set_start_from.js
+++ b/app/cms/static/js/set_start_from.js
@@ -16,11 +16,38 @@ document.addEventListener("DOMContentLoaded", function () {
     return;
   }
 
+  const dedicatedUserId = userSelect.getAttribute("data-dedicated-user-id");
+
+  function determineSeriesKey(selectedOption) {
+    if (!selectedOption) {
+      return "shared";
+    }
+
+    const selectedValue = selectedOption.value;
+    if (
+      dedicatedUserId !== null &&
+      dedicatedUserId !== undefined &&
+      dedicatedUserId !== "" &&
+      selectedValue !== undefined &&
+      selectedValue !== null &&
+      selectedValue !== "" &&
+      String(selectedValue) === String(dedicatedUserId)
+    ) {
+      return "tbi";
+    }
+
+    const label = selectedOption.textContent?.trim().toLowerCase();
+    if (label && label.includes("tbi")) {
+      return "tbi";
+    }
+
+    return "shared";
+  }
+
   function updateFields(force = false) {
     const selectedOption = userSelect.options[userSelect.selectedIndex];
-    const label = selectedOption?.textContent?.trim().toLowerCase();
 
-    const seriesKey = label.includes("tbi") ? "tbi" : "shared";
+    const seriesKey = determineSeriesKey(selectedOption);
     const nextStart = seriesMap[seriesKey];
 
     if (!nextStart) return;

--- a/app/cms/static/js/set_start_from.js
+++ b/app/cms/static/js/set_start_from.js
@@ -44,6 +44,12 @@ document.addEventListener("DOMContentLoaded", function () {
     return "shared";
   }
 
+  function dispatchInputEvent(element) {
+    if (!element) return;
+
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
   function updateFields(force = false) {
     const selectedOption = userSelect.options[userSelect.selectedIndex];
 
@@ -52,14 +58,22 @@ document.addEventListener("DOMContentLoaded", function () {
 
     if (!nextStart) return;
 
+    const nextStartValue = String(nextStart);
+    let startValueChanged = false;
+
     if (force || !startFromInput.value || startFromInput.value === "0") {
-      startFromInput.value = nextStart;
+      startValueChanged = startFromInput.value !== nextStartValue;
+      startFromInput.value = nextStartValue;
       startFromInput.readOnly = true;
     }
 
     if (force || !currentNumberInput.value || currentNumberInput.value === "0") {
-      currentNumberInput.value = nextStart;
+      currentNumberInput.value = nextStartValue;
       currentNumberInput.readOnly = true;
+    }
+
+    if (startValueChanged) {
+      dispatchInputEvent(startFromInput);
     }
   }
 

--- a/app/cms/static/js/set_start_from.js
+++ b/app/cms/static/js/set_start_from.js
@@ -20,7 +20,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const selectedOption = userSelect.options[userSelect.selectedIndex];
     const label = selectedOption?.textContent?.trim().toLowerCase();
 
-    const seriesKey = label.includes("mary") ? "mary" : "shared";
+    const seriesKey = label.includes("tbi") ? "tbi" : "shared";
     const nextStart = seriesMap[seriesKey];
 
     if (!nextStart) return;

--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 from datetime import timedelta
 from types import SimpleNamespace
+import json
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
@@ -117,6 +118,19 @@ class AccessionNumberSeriesAdminFormTests(TestCase):
         self.tbi_user = User.objects.create_user(username="TBI", password="pass")
         self.shared_user = User.objects.create_user(username="shared", password="pass")
         self.other_shared_user = User.objects.create_user(username="shared2", password="pass")
+
+    def test_form_exposes_widget_metadata_for_client_side(self):
+        form = AccessionNumberSeriesAdminForm()
+
+        widget_attrs = form.fields["user"].widget.attrs
+        self.assertEqual(
+            widget_attrs.get("data-dedicated-user-id"),
+            str(self.tbi_user.pk),
+        )
+
+        series_map = json.loads(widget_attrs["data-series-starts"])
+        self.assertEqual(series_map["tbi"], 1_000_000)
+        self.assertEqual(series_map["shared"], 1)
 
     def test_tbi_series_uses_dedicated_pool(self):
         form = AccessionNumberSeriesAdminForm(data={

--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -38,7 +38,7 @@ from cms.models import (
     NatureOfSpecimen,
 )
 from cms.utils import generate_accessions_from_series
-from cms.forms import DrawerRegisterForm
+from cms.forms import DrawerRegisterForm, AccessionNumberSeriesAdminForm
 from cms.filters import DrawerRegisterFilter
 from cms.resources import DrawerRegisterResource, PlaceResource
 from tablib import Dataset
@@ -109,6 +109,79 @@ class GenerateAccessionsFromSeriesTests(TestCase):
                 specimen_prefix=self.locality,
                 creator_user=self.creator,
             )
+
+
+class AccessionNumberSeriesAdminFormTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.tbi_user = User.objects.create_user(username="TBI", password="pass")
+        self.shared_user = User.objects.create_user(username="shared", password="pass")
+        self.other_shared_user = User.objects.create_user(username="shared2", password="pass")
+
+    def test_tbi_series_uses_dedicated_pool(self):
+        form = AccessionNumberSeriesAdminForm(data={
+            "user": str(self.tbi_user.pk),
+            "count": "5",
+            "start_from": "",
+            "current_number": "",
+            "is_active": "True",
+        })
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        series = form.save()
+        self.assertEqual(series.user, self.tbi_user)
+        self.assertEqual(series.start_from, 1_000_000)
+        self.assertEqual(series.current_number, 1_000_000)
+        self.assertEqual(series.end_at, 1_000_004)
+
+    def test_tbi_series_advances_after_existing_range(self):
+        AccessionNumberSeries.objects.create(
+            user=self.tbi_user,
+            start_from=1_000_000,
+            end_at=1_000_009,
+            current_number=1_000_005,
+            is_active=False,
+        )
+
+        form = AccessionNumberSeriesAdminForm(data={
+            "user": str(self.tbi_user.pk),
+            "count": "3",
+            "start_from": "",
+            "current_number": "",
+            "is_active": "True",
+        })
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        series = form.save()
+        self.assertEqual(series.start_from, 1_000_010)
+        self.assertEqual(series.current_number, 1_000_010)
+        self.assertEqual(series.end_at, 1_000_012)
+
+    def test_shared_series_uses_shared_pool(self):
+        AccessionNumberSeries.objects.create(
+            user=self.shared_user,
+            start_from=1,
+            end_at=50,
+            current_number=10,
+            is_active=False,
+        )
+
+        form = AccessionNumberSeriesAdminForm(data={
+            "user": str(self.other_shared_user.pk),
+            "count": "10",
+            "start_from": "",
+            "current_number": "",
+            "is_active": "True",
+        })
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        series = form.save()
+        self.assertEqual(series.start_from, 51)
+        self.assertEqual(series.current_number, 51)
+        self.assertEqual(series.end_at, 60)
 
 
 class PreparationUpdateViewTests(TestCase):

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -1,8 +1,10 @@
 # Admin Guides
 
+- [Accession Number Series](accession-number-series.md)
 - [Drawer Register](drawer-register.md)
 - [Localities](localities.md)
 - [Places](places.md)
 - [References](references.md)
 - [Preparations](preparations.md)
 - [Scan Uploads](scan-uploads.md)
+- [Users](users.md)

--- a/docs/admin/accession-number-series.md
+++ b/docs/admin/accession-number-series.md
@@ -1,6 +1,6 @@
 # Accession Number Series (Admin)
 
-Accession number series issue sequential specimen numbers to individual users. Each series tracks the next number that will be assigned when a collection manager generates accessions, and only one active series is allowed per user at a time. Series created for the user **mary** use a dedicated numbering pool that starts at one million; every other user shares a pool that starts at one.
+Accession number series issue sequential specimen numbers to individual users. Each series tracks the next number that will be assigned when a collection manager generates accessions, and only one active series is allowed per user at a time. Series created for the organisation user **TBI** use a dedicated numbering pool that starts at one million; every other user shares a pool that starts at one.
 
 ## Creating a series
 
@@ -22,7 +22,7 @@ Collection managers see shortcuts to create single accessions or batches only wh
 
 1. Open the user’s existing accession number series from the admin list.
 2. Confirm the current range has been fully used and is now marked inactive. Only one active range is allowed per user, so wait for the current numbers to be exhausted before issuing more.
-3. Add a new series for the same user. The form again proposes the next available number—either right after the previous shared pool range or, for Mary’s dedicated pool, immediately after her last issued number.
+3. Add a new series for the same user. The form again proposes the next available number—either right after the previous shared pool range or, for TBI’s dedicated pool, immediately after the last issued number.
 4. Save the record to activate the new range.
 
 Deactivate any old series as soon as the numbers are exhausted. This prevents overlapping ranges and ensures the correct counts are displayed to collection managers while they work.

--- a/docs/admin/accession-number-series.md
+++ b/docs/admin/accession-number-series.md
@@ -1,0 +1,28 @@
+# Accession Number Series (Admin)
+
+Accession number series issue sequential specimen numbers to individual users. Each series tracks the next number that will be assigned when a collection manager generates accessions, and only one active series is allowed per user at a time. Series created for the user **mary** use a dedicated numbering pool that starts at one million; every other user shares a pool that starts at one.
+
+## Creating a series
+
+1. Sign in to the Django admin and open **Accession number series**.
+2. Select **Add accession number series**.
+3. Choose the user the range belongs to. The form pre-populates **Start from** and **Current number** with the next available number for that user’s pool.
+4. Enter the **Count** of accession numbers you want to allocate. The live preview beneath the field shows the exact range that will be generated before you save.
+5. Leave **Is active** checked so the user can draw from the new range, then choose **Save**.
+
+When the record is saved the system calculates the **End at** value automatically. Existing series entries become read-only so the allocation history stays intact.
+
+## Monitoring usage
+
+Whenever accession numbers are generated for the assigned user, the series automatically advances its **Current number**. You can review the remaining numbers by comparing **Current number** and **End at**, or open the history tab in the admin to see when the range changed. When the final number in the range is used the system marks the series as inactive for you.
+
+Collection managers see shortcuts to create single accessions or batches only when they have an active series, so removing access will hide those options from their dashboard.
+
+## Starting a new range for a user
+
+1. Open the user’s existing accession number series from the admin list.
+2. Confirm the current range has been fully used and is now marked inactive. Only one active range is allowed per user, so wait for the current numbers to be exhausted before issuing more.
+3. Add a new series for the same user. The form again proposes the next available number—either right after the previous shared pool range or, for Mary’s dedicated pool, immediately after her last issued number.
+4. Save the record to activate the new range.
+
+Deactivate any old series as soon as the numbers are exhausted. This prevents overlapping ranges and ensures the correct counts are displayed to collection managers while they work.

--- a/docs/admin/users.md
+++ b/docs/admin/users.md
@@ -1,0 +1,29 @@
+# Users (Admin)
+
+Use the Django administration site to create accounts and control what each person can do in the collections management system.
+
+## Adding a new user
+
+1. Sign in to the Django admin and open **Users** under **Authentication and Authorization**.
+2. Select **Add user**.
+3. Enter a unique **Username** and an initial **Password**, then choose **Save and continue editing** to open the full profile form.
+4. Fill in the person’s name and email details. Leave **Active** checked so the account can sign in. Enable **Staff status** only if the user needs access to the admin itself, and reserve **Superuser status** for system maintainers.
+5. Choose **Save** when you are finished.
+
+## Assigning the user to a group
+
+Group membership controls which features appear for the user inside the site.
+
+1. Open the user record you just created (or any existing account) in the Django admin.
+2. Scroll to the **Permissions** section.
+3. Use the **Groups** selector to move the appropriate roles into the **Chosen groups** list. Hold `Ctrl` (or `Cmd` on macOS) to select multiple entries.
+4. Select **Save** to apply the changes.
+
+### Common groups
+
+- **Collection Managers** – unlocks tools for managing drawers, creating accessions, and uploading scans.
+- **Curators** – grants read access to unpublished accession content for review.
+- **Interns** – limits the dashboard to scanning tasks so interns can start and stop drawer sessions.
+- **Preparators** – allows preparators to record and update preparation work.
+
+Refer to the [User Rights](../user-rights.md) guide for a complete summary of the capabilities each role provides.

--- a/docs/user-rights.md
+++ b/docs/user-rights.md
@@ -4,44 +4,44 @@ This guide outlines which navigation entries are visible to each role and what c
 
 ## Roles
 
-- **Public user** – an unauthenticated visitor or anyone without a staff group assignment; they only see the login prompt in the sidebar.【F:app/cms/templates/base_generic.html†L63-L73】
-- **Curator** – member of the Curators group, gaining access to curator dashboards and preparation workflows.【F:app/cms/views.py†L220-L233】【F:app/cms/views.py†L946-L960】
-- **Collection manager** – member of the Collection Managers group, unlocking accession management, locality editing, and storage tools.【F:app/cms/views.py†L234-L267】【F:app/cms/views.py†L115-L116】
-- **Preparator** – member of the Preparators group who can update the preparation records assigned to them.【F:app/cms/views.py†L980-L995】【F:app/cms/views.py†L1017-L1091】
-- **Intern** – member of the Interns group with access to the scanning dashboard for drawers assigned to them.【F:app/cms/views.py†L269-L285】
-- **Superuser** – Django administrators who satisfy every permission check in the navigation and view logic.【F:app/cms/templates/base_generic.html†L50-L61】【F:app/cms/views.py†L449-L457】
+- **Public user** – an unauthenticated visitor or anyone without a staff group assignment; they only see the login prompt in the sidebar.
+- **Curator** – member of the Curators group, gaining access to curator dashboards and preparation workflows.
+- **Collection manager** – member of the Collection Managers group, unlocking accession management, locality editing, and storage tools.
+- **Preparator** – member of the Preparators group who can update the preparation records assigned to them.
+- **Intern** – member of the Interns group with access to the scanning dashboard for drawers assigned to them.
+- **Superuser** – Django administrators who satisfy every permission check in the navigation and view logic.
 
 ## Accessions
 
-The Accessions link is always visible in the sidebar navigation.【F:app/cms/templates/base_generic.html†L45-L61】 The list and detail views filter out unpublished records for anyone who is not a curator, collection manager, or superuser, so public visitors, interns, and preparators only see published entries.【F:app/cms/views.py†L517-L534】【F:app/cms/views.py†L464-L472】 Curators may browse the full catalogue but the creation and editing endpoints are guarded by the collection-manager check, leaving them read-only on the public site.【F:app/cms/views.py†L517-L534】【F:app/cms/views.py†L793-L944】 Collection managers and superusers can create accessions, add related content, and edit existing records through those protected views.【F:app/cms/views.py†L793-L944】
+The Accessions link is always visible in the sidebar navigation. The list and detail views filter out unpublished records for anyone who is not a curator, collection manager, or superuser, so public visitors, interns, and preparators only see published entries. Curators may browse the full catalogue but the creation and editing endpoints are guarded by the collection-manager check, leaving them read-only on the public site. Collection managers and superusers can create accessions, add related content, and edit existing records through those protected views.
 
 ## Localities
 
-Localities are visible to every visitor via the sidebar.【F:app/cms/templates/base_generic.html†L45-L61】 The list view has no access restriction, but locality details only expose unpublished accessions to authenticated curators, collection managers, or superusers.【F:app/cms/views.py†L676-L706】 Creating a new locality requires collection-manager privileges, and only the same roles see the edit button on the detail page.【F:app/cms/views.py†L377-L414】【F:app/cms/templates/cms/locality_detail.html†L11-L49】 Everyone else—including preparators and interns—can browse locality information but cannot change it.
+Localities are visible to every visitor via the sidebar. The list view has no access restriction, but locality details only expose unpublished accessions to authenticated curators, collection managers, or superusers. Creating a new locality requires collection-manager privileges, and only the same roles see the edit button on the detail page. Everyone else—including preparators and interns—can browse locality information but cannot change it.
 
 ## Places
 
-Places are also always visible in navigation.【F:app/cms/templates/base_generic.html†L45-L61】 Anyone can browse the list and detail pages, but only superusers and collection managers pass the `can_manage_places` check that protects the create and edit forms.【F:app/cms/views.py†L115-L116】【F:app/cms/views.py†L417-L441】 As a result, curators, preparators, interns, and the public have read-only access to places from the public site.
+Places are also always visible in navigation. Anyone can browse the list and detail pages, but only superusers and collection managers pass the `can_manage_places` check that protects the create and edit forms. As a result, curators, preparators, interns, and the public have read-only access to places from the public site.
 
 ## References
 
-References appear for every visitor and the list view is unrestricted.【F:app/cms/templates/base_generic.html†L45-L61】【F:app/cms/views.py†L663-L673】 The “New Reference” button and detail-page edit link show only for superusers and collection managers, reflecting that those roles manage the bibliography.【F:app/cms/templates/cms/reference_list.html†L13-L18】 Other roles can view references but cannot add or modify them through the front end.
+References appear for every visitor and the list view is unrestricted. The “New Reference” button and detail-page edit link show only for superusers and collection managers, reflecting that those roles manage the bibliography. Other roles can view references but cannot add or modify them through the front end.
 
 ## Field Slips
 
-Field Slips are a specialist tool: the sidebar entry only appears for superusers and collection managers, and the list view enforces the same requirement.【F:app/cms/templates/base_generic.html†L50-L61】【F:app/cms/views.py†L449-L457】 Those roles can create and edit slips using the dedicated forms surfaced in the list and detail templates.【F:app/cms/templates/cms/fieldslip_list.html†L14-L18】【F:app/cms/views.py†L301-L320】 Curators, preparators, interns, and the public do not see the navigation item and cannot reach the list because of the access check.
+Field Slips are a specialist tool: the sidebar entry only appears for superusers and collection managers, and the list view enforces the same requirement. Those roles can create and edit slips using the dedicated forms surfaced in the list and detail templates. Curators, preparators, interns, and the public do not see the navigation item and cannot reach the list because of the access check.
 
 ## Preparations
 
-The Preparations link is visible to superusers, collection managers, and curators; preparators and other users do not see it.【F:app/cms/templates/base_generic.html†L54-L56】 The list view applies the same restriction, so only those roles can browse all preparations or launch the “New Preparation” flow.【F:app/cms/views.py†L946-L973】 Within individual records, superusers can always edit, curators can edit or delete when they are the assigned curator, and preparators can update records assigned to them even though they must reach the page via a direct link or notification rather than navigation.【F:app/cms/views.py†L980-L1091】 Collection managers can start new preparations but must rely on the assigned curator or preparator to update or finish them.【F:app/cms/views.py†L946-L1091】
+The Preparations link is visible to superusers, collection managers, and curators; preparators and other users do not see it. The list view applies the same restriction, so only those roles can browse all preparations or launch the “New Preparation” flow. Within individual records, superusers can always edit, curators can edit or delete when they are the assigned curator, and preparators can update records assigned to them even though they must reach the page via a direct link or notification rather than navigation. Collection managers can start new preparations but must rely on the assigned curator or preparator to update or finish them.
 
 ## Drawers
 
-Drawer management is limited to superusers and collection managers: the navigation entries, list view, and all CRUD views share a mixin that checks for those roles.【F:app/cms/templates/base_generic.html†L58-L60】【F:app/cms/views.py†L1298-L1428】 Interns interact with drawers through the dashboard scanning workflow instead, where they can see drawers assigned to them and start or stop scanning sessions.【F:app/cms/views.py†L269-L285】【F:app/cms/views.py†L1431-L1437】 All other roles have no navigation access to drawer registers.
+Drawer management is limited to superusers and collection managers: the navigation entries, list view, and all CRUD views share a mixin that checks for those roles. Interns interact with drawers through the dashboard scanning workflow instead, where they can see drawers assigned to them and start or stop scanning sessions. All other roles have no navigation access to drawer registers.
 
 ## Storages
 
-Storage areas follow the same pattern: only superusers and collection managers see the navigation entry, pass the access mixin, and can create or edit storage records.【F:app/cms/templates/base_generic.html†L58-L61】【F:app/cms/views.py†L1298-L1375】 Other roles, including curators, preparators, interns, and the public, cannot reach the storage list through the front-end navigation.
+Storage areas follow the same pattern: only superusers and collection managers see the navigation entry, pass the access mixin, and can create or edit storage records. Other roles, including curators, preparators, interns, and the public, cannot reach the storage list through the front-end navigation.
 
 ## Summary of CRUD Rights
 
@@ -58,6 +58,6 @@ Storage areas follow the same pattern: only superusers and collection managers s
 | Drawers | 🚫 | 🚫 | C,R,U | 🚫 | 🚫 | C,R,U |
 | Storages | 🚫 | 🚫 | C,R,U | 🚫 | 🚫 | C,R,U |
 
-*Curators can update or delete a preparation only when they are the assigned curator, and preparators can update the records assigned to them; collection managers launch new preparations but must rely on the assigned staff to revise them.【F:app/cms/views.py†L980-L1109】*
+*Curators can update or delete a preparation only when they are the assigned curator, and preparators can update the records assigned to them; collection managers launch new preparations but must rely on the assigned staff to revise them.*
 
-†Preparators do not see the Preparations link in navigation but can edit the records where they are set as the preparator when given a direct link.【F:app/cms/templates/base_generic.html†L54-L56】【F:app/cms/views.py†L980-L1091】
+†Preparators do not see the Preparations link in navigation but can edit the records where they are set as the preparator when given a direct link.

--- a/docs/user-rights.md
+++ b/docs/user-rights.md
@@ -1,32 +1,63 @@
 # User Rights
 
-This guide outlines visibility and operations available to different user roles.
+This guide outlines which navigation entries are visible to each role and what create/read/update/delete (CRUD) actions are available in the public site. Superusers can always fall back to the Django admin for operations that are not surfaced in the application UI.
 
 ## Roles
-- **Public User** – not authenticated.
-- **Curator** – member of the "Curators" group.
-- **Collection Manager** – member of the "Collection Managers" group.
-- **Superuser** – Django administrator with all permissions.
 
-## Scan Uploads
-- **Collection Manager / Superuser**: may upload scan images using the admin **Upload scans** button.
-- **Curator / Public User**: no access.
+- **Public user** – an unauthenticated visitor or anyone without a staff group assignment; they only see the login prompt in the sidebar.【F:app/cms/templates/base_generic.html†L63-L73】
+- **Curator** – member of the Curators group, gaining access to curator dashboards and preparation workflows.【F:app/cms/views.py†L220-L233】【F:app/cms/views.py†L946-L960】
+- **Collection manager** – member of the Collection Managers group, unlocking accession management, locality editing, and storage tools.【F:app/cms/views.py†L234-L267】【F:app/cms/views.py†L115-L116】
+- **Preparator** – member of the Preparators group who can update the preparation records assigned to them.【F:app/cms/views.py†L980-L995】【F:app/cms/views.py†L1017-L1091】
+- **Intern** – member of the Interns group with access to the scanning dashboard for drawers assigned to them.【F:app/cms/views.py†L269-L285】
+- **Superuser** – Django administrators who satisfy every permission check in the navigation and view logic.【F:app/cms/templates/base_generic.html†L50-L61】【F:app/cms/views.py†L449-L457】
 
-## Accession
-- **Public User**: can view only published accessions on list pages and locality details. Attempting to access an unpublished accession detail returns a 404 page. No editing actions are available.
-- **Curator**: can view all accessions, including unpublished ones, but cannot create or edit them.
-- **Collection Manager / Superuser**: full access to all accessions. They may view unpublished records, edit accession information, and manage related data such as geology, specimens, references, comments, and media.
+## Accessions
 
-## Locality
-- **Public User**: can view locality pages. Only published accessions are listed for each locality. Editing is not allowed.
-- **Curator**: can view all accessions associated with a locality, regardless of publication state.
-- **Collection Manager / Superuser**: can edit localities and see all associated accessions, including who accessioned them.
+The Accessions link is always visible in the sidebar navigation.【F:app/cms/templates/base_generic.html†L45-L61】 The list and detail views filter out unpublished records for anyone who is not a curator, collection manager, or superuser, so public visitors, interns, and preparators only see published entries.【F:app/cms/views.py†L517-L534】【F:app/cms/views.py†L464-L472】 Curators may browse the full catalogue but the creation and editing endpoints are guarded by the collection-manager check, leaving them read-only on the public site.【F:app/cms/views.py†L517-L534】【F:app/cms/views.py†L793-L944】 Collection managers and superusers can create accessions, add related content, and edit existing records through those protected views.【F:app/cms/views.py†L793-L944】
 
-## Place
-- **Public User**: can view place pages.
-- **Curator**: can view all places and their higher and lower geographies.
-- **Collection Manager**: can add and edit places and manage their relationships, but cannot delete them.
-- **Superuser**: can add, edit or delete places and manage their relationships.
+## Localities
 
-When managing relationships, related places must belong to the same locality and circular hierarchies are not permitted.
+Localities are visible to every visitor via the sidebar.【F:app/cms/templates/base_generic.html†L45-L61】 The list view has no access restriction, but locality details only expose unpublished accessions to authenticated curators, collection managers, or superusers.【F:app/cms/views.py†L676-L706】 Creating a new locality requires collection-manager privileges, and only the same roles see the edit button on the detail page.【F:app/cms/views.py†L377-L414】【F:app/cms/templates/cms/locality_detail.html†L11-L49】 Everyone else—including preparators and interns—can browse locality information but cannot change it.
 
+## Places
+
+Places are also always visible in navigation.【F:app/cms/templates/base_generic.html†L45-L61】 Anyone can browse the list and detail pages, but only superusers and collection managers pass the `can_manage_places` check that protects the create and edit forms.【F:app/cms/views.py†L115-L116】【F:app/cms/views.py†L417-L441】 As a result, curators, preparators, interns, and the public have read-only access to places from the public site.
+
+## References
+
+References appear for every visitor and the list view is unrestricted.【F:app/cms/templates/base_generic.html†L45-L61】【F:app/cms/views.py†L663-L673】 The “New Reference” button and detail-page edit link show only for superusers and collection managers, reflecting that those roles manage the bibliography.【F:app/cms/templates/cms/reference_list.html†L13-L18】 Other roles can view references but cannot add or modify them through the front end.
+
+## Field Slips
+
+Field Slips are a specialist tool: the sidebar entry only appears for superusers and collection managers, and the list view enforces the same requirement.【F:app/cms/templates/base_generic.html†L50-L61】【F:app/cms/views.py†L449-L457】 Those roles can create and edit slips using the dedicated forms surfaced in the list and detail templates.【F:app/cms/templates/cms/fieldslip_list.html†L14-L18】【F:app/cms/views.py†L301-L320】 Curators, preparators, interns, and the public do not see the navigation item and cannot reach the list because of the access check.
+
+## Preparations
+
+The Preparations link is visible to superusers, collection managers, and curators; preparators and other users do not see it.【F:app/cms/templates/base_generic.html†L54-L56】 The list view applies the same restriction, so only those roles can browse all preparations or launch the “New Preparation” flow.【F:app/cms/views.py†L946-L973】 Within individual records, superusers can always edit, curators can edit or delete when they are the assigned curator, and preparators can update records assigned to them even though they must reach the page via a direct link or notification rather than navigation.【F:app/cms/views.py†L980-L1091】 Collection managers can start new preparations but must rely on the assigned curator or preparator to update or finish them.【F:app/cms/views.py†L946-L1091】
+
+## Drawers
+
+Drawer management is limited to superusers and collection managers: the navigation entries, list view, and all CRUD views share a mixin that checks for those roles.【F:app/cms/templates/base_generic.html†L58-L60】【F:app/cms/views.py†L1298-L1428】 Interns interact with drawers through the dashboard scanning workflow instead, where they can see drawers assigned to them and start or stop scanning sessions.【F:app/cms/views.py†L269-L285】【F:app/cms/views.py†L1431-L1437】 All other roles have no navigation access to drawer registers.
+
+## Storages
+
+Storage areas follow the same pattern: only superusers and collection managers see the navigation entry, pass the access mixin, and can create or edit storage records.【F:app/cms/templates/base_generic.html†L58-L61】【F:app/cms/views.py†L1298-L1375】 Other roles, including curators, preparators, interns, and the public, cannot reach the storage list through the front-end navigation.
+
+## Summary of CRUD Rights
+
+`C` = create, `R` = read, `U` = update, `D` = delete, `🚫` = not visible in navigation/blocked. “Published” indicates that only published records are visible to the role. Preparations have role-specific nuances noted below.
+
+| Entity | Public | Curator | Collection Manager | Preparator | Intern | Superuser |
+| --- | --- | --- | --- | --- | --- | --- |
+| Accessions | R (published) | R (all) | C,R,U | R (published) | R (published) | C,R,U |
+| Localities | R | R | C,R,U | R | R | C,R,U |
+| Places | R | R | C,R,U | R | R | C,R,U |
+| References | R | R | C,R,U | R | R | C,R,U |
+| Field Slips | 🚫 | 🚫 | C,R,U | 🚫 | 🚫 | C,R,U |
+| Preparations | 🚫 | C,R,U,D* | C,R* | 🚫† | 🚫 | C,R,U,D |
+| Drawers | 🚫 | 🚫 | C,R,U | 🚫 | 🚫 | C,R,U |
+| Storages | 🚫 | 🚫 | C,R,U | 🚫 | 🚫 | C,R,U |
+
+*Curators can update or delete a preparation only when they are the assigned curator, and preparators can update the records assigned to them; collection managers launch new preparations but must rely on the assigned staff to revise them.【F:app/cms/views.py†L980-L1109】*
+
+†Preparators do not see the Preparations link in navigation but can edit the records where they are set as the preparator when given a direct link.【F:app/cms/templates/base_generic.html†L54-L56】【F:app/cms/views.py†L980-L1091】

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,6 +1,7 @@
 # User Guides
 
 - [Drawer Register](drawer-register.md)
+- [Scanning](scanning.md)
 - [Localities](localities.md)
 - [Places](places.md)
 - [References](references.md)

--- a/docs/user/scanning.md
+++ b/docs/user/scanning.md
@@ -5,24 +5,24 @@ The scanning workflow links assigned drawers to timed scanning sessions so that 
 ## Roles and access
 
 ### Collection Managers
-- Maintain drawer records and choose the correct scanning status for each drawer. When a drawer is set to *In progress*, managers must select the interns who will scan it.【F:docs/user/drawer-register.md†L3-L14】
-- Review drawer details to monitor the log of every scanning session and confirm when work is finished.【F:app/cms/templates/cms/drawerregister_detail.html†L12-L32】
+- Maintain drawer records and choose the correct scanning status for each drawer. When a drawer is set to *In progress*, managers must select the interns who will scan it.
+- Review drawer details to monitor the log of every scanning session and confirm when work is finished.
 
 ### Interns
-- See a **My Drawers** table on the dashboard listing only drawers that are marked *In progress* and assigned to them, including any active timer for work already underway.【F:app/cms/views.py†L269-L285】【F:app/cms/templates/cms/dashboard.html†L141-L205】
-- Start and stop scanning sessions from the dashboard buttons. The **Start scanning task** button is disabled whenever a session is already running, and the **Stop scanning task** button is disabled until a session has begun.【F:app/cms/templates/cms/dashboard.html†L178-L185】
+- See a **My Drawers** table on the dashboard listing only drawers that are marked *In progress* and assigned to them, including any active timer for work already underway.
+- Start and stop scanning sessions from the dashboard buttons. The **Start scanning task** button is disabled whenever a session is already running, and the **Stop scanning task** button is disabled until a session has begun.
 
 ## Preparing a drawer for scanning (Collection Managers)
-1. Open the Drawer Register and create or edit the drawer that needs to be scanned.【F:docs/user/drawer-register.md†L5-L22】
-2. Change the scanning status to *In progress* and select one or more interns in the **Scanning users** field. Save the drawer to publish the assignment.【F:docs/user/drawer-register.md†L9-L18】【F:app/cms/models.py†L1166-L1178】
-3. Update the status to *Scanned* once the scans have been reviewed so the drawer no longer appears in intern dashboards.【F:app/cms/models.py†L1166-L1174】
+1. Open the Drawer Register and create or edit the drawer that needs to be scanned.
+2. Change the scanning status to *In progress* and select one or more interns in the **Scanning users** field. Save the drawer to publish the assignment.
+3. Update the status to *Scanned* once the scans have been reviewed so the drawer no longer appears in intern dashboards.
 
 ## Running a scanning session (Interns)
-1. Sign in and open the dashboard. The **My Drawers** table shows every drawer you have been assigned that is currently in progress.【F:app/cms/views.py†L269-L285】【F:app/cms/templates/cms/dashboard.html†L141-L176】
-2. Click **Start scanning task** when you begin scanning. The system records the start time and displays a live timer while the session is active.【F:app/cms/views.py†L1431-L1437】【F:app/cms/templates/cms/dashboard.html†L164-L204】
-3. Click **Stop scanning task** as soon as you finish with the drawer. The timer stops and the end time is saved to the scan log for managers to review.【F:app/cms/views.py†L1439-L1451】【F:app/cms/templates/cms/drawerregister_detail.html†L12-L27】
-4. If further work is needed later, repeat the start/stop process. Each pair of actions creates a new entry in the drawer’s scan history, ensuring the project tracks how long each session lasted.【F:app/cms/views.py†L1431-L1451】【F:app/cms/templates/cms/drawerregister_detail.html†L12-L32】
+1. Sign in and open the dashboard. The **My Drawers** table shows every drawer you have been assigned that is currently in progress.
+2. Click **Start scanning task** when you begin scanning. The system records the start time and displays a live timer while the session is active.
+3. Click **Stop scanning task** as soon as you finish with the drawer. The timer stops and the end time is saved to the scan log for managers to review.
+4. If further work is needed later, repeat the start/stop process. Each pair of actions creates a new entry in the drawer’s scan history, ensuring the project tracks how long each session lasted.
 
 ## Monitoring progress (Collection Managers)
-- Use the drawer detail page to review who scanned the drawer and how long each session lasted before approving the work or updating the status.【F:app/cms/templates/cms/drawerregister_detail.html†L12-L32】
-- Adjust assignments or statuses as needed so that only active tasks remain visible to interns on the dashboard.【F:docs/user/drawer-register.md†L9-L22】【F:app/cms/views.py†L269-L285】
+- Use the drawer detail page to review who scanned the drawer and how long each session lasted before approving the work or updating the status.
+- Adjust assignments or statuses as needed so that only active tasks remain visible to interns on the dashboard.

--- a/docs/user/scanning.md
+++ b/docs/user/scanning.md
@@ -1,0 +1,28 @@
+# Scanning
+
+The scanning workflow links assigned drawers to timed scanning sessions so that managers and interns can coordinate digitization work.
+
+## Roles and access
+
+### Collection Managers
+- Maintain drawer records and choose the correct scanning status for each drawer. When a drawer is set to *In progress*, managers must select the interns who will scan it.【F:docs/user/drawer-register.md†L3-L14】
+- Review drawer details to monitor the log of every scanning session and confirm when work is finished.【F:app/cms/templates/cms/drawerregister_detail.html†L12-L32】
+
+### Interns
+- See a **My Drawers** table on the dashboard listing only drawers that are marked *In progress* and assigned to them, including any active timer for work already underway.【F:app/cms/views.py†L269-L285】【F:app/cms/templates/cms/dashboard.html†L141-L205】
+- Start and stop scanning sessions from the dashboard buttons. The **Start scanning task** button is disabled whenever a session is already running, and the **Stop scanning task** button is disabled until a session has begun.【F:app/cms/templates/cms/dashboard.html†L178-L185】
+
+## Preparing a drawer for scanning (Collection Managers)
+1. Open the Drawer Register and create or edit the drawer that needs to be scanned.【F:docs/user/drawer-register.md†L5-L22】
+2. Change the scanning status to *In progress* and select one or more interns in the **Scanning users** field. Save the drawer to publish the assignment.【F:docs/user/drawer-register.md†L9-L18】【F:app/cms/models.py†L1166-L1178】
+3. Update the status to *Scanned* once the scans have been reviewed so the drawer no longer appears in intern dashboards.【F:app/cms/models.py†L1166-L1174】
+
+## Running a scanning session (Interns)
+1. Sign in and open the dashboard. The **My Drawers** table shows every drawer you have been assigned that is currently in progress.【F:app/cms/views.py†L269-L285】【F:app/cms/templates/cms/dashboard.html†L141-L176】
+2. Click **Start scanning task** when you begin scanning. The system records the start time and displays a live timer while the session is active.【F:app/cms/views.py†L1431-L1437】【F:app/cms/templates/cms/dashboard.html†L164-L204】
+3. Click **Stop scanning task** as soon as you finish with the drawer. The timer stops and the end time is saved to the scan log for managers to review.【F:app/cms/views.py†L1439-L1451】【F:app/cms/templates/cms/drawerregister_detail.html†L12-L27】
+4. If further work is needed later, repeat the start/stop process. Each pair of actions creates a new entry in the drawer’s scan history, ensuring the project tracks how long each session lasted.【F:app/cms/views.py†L1431-L1451】【F:app/cms/templates/cms/drawerregister_detail.html†L12-L32】
+
+## Monitoring progress (Collection Managers)
+- Use the drawer detail page to review who scanned the drawer and how long each session lasted before approving the work or updating the status.【F:app/cms/templates/cms/drawerregister_detail.html†L12-L32】
+- Adjust assignments or statuses as needed so that only active tasks remain visible to interns on the dashboard.【F:docs/user/drawer-register.md†L9-L22】【F:app/cms/views.py†L269-L285】


### PR DESCRIPTION
## Summary
- add a scanning workflow user guide describing the roles of collection managers and interns
- link the new guide from the user documentation index

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cbdc3f157c8329a827bc3b356f4019