### PR TITLE
Group key place and locality details

### DIFF
--- a/app/cms/templates/cms/accession_detail.html
+++ b/app/cms/templates/cms/accession_detail.html
@@ -79,6 +79,9 @@
                         <tr>
                             <th>Specimen</th>
                             <th>Storage</th>
+                            <th>Element</th>
+                            <th>Side</th>
+                            <th>Description</th>
                             <th>Taxon</th>
                             <th>Family</th>
                             <th>Subfamily</th>
@@ -88,11 +91,39 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for accessionrow in accession.accessionrow_set.all %}                   
+                        {% for accessionrow in accession_rows %}
+                            {% with specimens=accessionrow.natureofspecimen_set.all %}
                             <tr>
                                 <td><a href="{% url 'accessionrow_detail' accessionrow.pk %}">{{ accessionrow.specimen_suffix }}</a></td>
                                 <td>{{ accessionrow.storage }}</td>
-                        
+                                <td>
+                                    {% if specimens %}
+                                        {% for specimen in specimens %}
+                                            {{ specimen.element|default:"—" }}{% if not forloop.last %}<br>{% endif %}
+                                        {% endfor %}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if specimens %}
+                                        {% for specimen in specimens %}
+                                            {{ specimen.side|default:"—" }}{% if not forloop.last %}<br>{% endif %}
+                                        {% endfor %}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if specimens %}
+                                        {% for specimen in specimens %}
+                                            {{ specimen.verbatim_element|default:"—" }}{% if not forloop.last %}<br>{% endif %}
+                                        {% endfor %}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+
                                 {% with first_identifications|get_item:accessionrow.id as first_identification %}
                                     {% if first_identification %}
                                         {% with taxonomy|get_item:first_identification.id as matched_taxon %}
@@ -118,9 +149,10 @@
                                     {% endif %}
                                 {% endwith %}
                             </tr>
-                        {% endfor %}                    
+                            {% endwith %}
+                        {% endfor %}
                     </tbody>
-                </table>                
+                </table>
                 <hr class="accession_hr">
                 {% if user.is_authenticated and user|has_group:"Collection Managers" %}
                   <a href="{% url 'accession_add_reference' accession.id %}">➕ Add Reference</a>

--- a/app/cms/templates/cms/locality_detail.html
+++ b/app/cms/templates/cms/locality_detail.html
@@ -19,11 +19,6 @@
                 <!-- Field Number Card -->
                 <div class="card">
                     <p><strong>Abbreviation: </strong> <br> {{ locality.abbreviation }}</p>
-                                     
-                </div>
-    
-                <!-- Verbatim Taxon Card -->
-                <div class="card">
                     <p><strong>Name:</strong> <br> {{ locality.name }} </p>
                 </div>
 

--- a/app/cms/templates/cms/place_detail.html
+++ b/app/cms/templates/cms/place_detail.html
@@ -14,15 +14,15 @@
     <div class="grid-container">
         <div class="card">
             <p><strong>Name:</strong> <br> {{ place.name }}</p>
-        </div>
-        <div class="card">
             <p><strong>Type:</strong> <br> {{ place.get_place_type_display }}</p>
-        </div>
-        <div class="card">
             <p><strong>Locality:</strong> <br> {{ place.locality.abbreviation }}</p>
-        </div>
-        <div class="card">
             <p><strong>Higher Geography:</strong> <br> {{ place.part_of_hierarchy }}</p>
+            {% if place.description %}
+            <p><strong>Description:</strong> <br> {{ place.description }}</p>
+            {% endif %}
+            {% if place.comment %}
+            <p><strong>Comment:</strong> <br> {{ place.comment }}</p>
+            {% endif %}
         </div>
         {% if children %}
         <div class="card">
@@ -36,16 +36,6 @@
         {% if place.related_place %}
         <div class="card">
             <p><strong>Relation:</strong> <br> {{ place.get_relation_type_display }} → {{ place.related_place.name }}</p>
-        </div>
-        {% endif %}
-        {% if place.description %}
-        <div class="card">
-            <p><strong>Description:</strong> <br> {{ place.description }}</p>
-        </div>
-        {% endif %}
-        {% if place.comment %}
-        <div class="card">
-            <p><strong>Comment:</strong> <br> {{ place.comment }}</p>
         </div>
         {% endif %}
     </div>

--- a/app/cms/templates/cms/reference_detail.html
+++ b/app/cms/templates/cms/reference_detail.html
@@ -29,31 +29,76 @@
                 <div class="card">
                     <p><strong>Journal:</strong> <br> {{ reference.journal }}</p>
                     <p><strong>Volume: </strong> <br> {{ reference.volume }}</p>
-                    <p><strong>Issue:</strong> <br> {{ reference.issue}} </p>           
+                    <p><strong>Issue:</strong> <br> {{ reference.issue }}</p>
                     <p><strong>Pages: </strong> <br> {{ reference.pages }}</p>
-                    <p><strong>DOI: </strong> <br> <a href="https://doi.org/10.1016/j.jhevol.2008.02.001" target="_blank">{{ reference.doi }}</a>
-            
-                    
+                    {% if doi_url %}
+                    <p>
+                        <strong>DOI: </strong>
+                        <br>
+                        <a href="{{ doi_url }}" target="_blank" rel="noopener">{{ reference.doi }}</a>
+                    </p>
+                    {% endif %}
                 </div>
                 
                 <div class="card">
                     <p><strong>Citation:</strong> <br> {{ reference.citation }}</p>
-                    
-                </div>               
-    
-                
+
+                </div>
+
+
+                <div class="cards">
+                    <table class="w3-table-all w3-hoverable">
+                        <caption class="w3-large"><strong>Accession details</strong></caption>
+                        <thead>
+                            <tr>
+                                <th>Collection</th>
+                                <th>Specimen Prefix</th>
+                                <th>Specimen Number</th>
+                                <th>Taxon</th>
+                                <th>Element</th>
+                                <th>Page(s)</th>
+                                {% if user.is_superuser or user|has_group:"Collection Managers" %}
+                                <th>Accessioned by</th>
+                                {% endif %}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for accession, page in accession_entries %}
+                            <tr>
+                                <td>{{ accession.collection.abbreviation }}</td>
+                                <td>{{ accession.specimen_prefix.abbreviation }}</td>
+                                <td><a href="{% url 'accession_detail' accession.pk %}">{{ accession.specimen_no }}</a></td>
+                                <td>
+                                    {% if accession.taxa_list %}
+                                        {{ accession.taxa_list|join:", " }}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if accession.element_list %}
+                                        {{ accession.element_list|join:", " }}
+                                    {% else %}
+                                        &mdash;
+                                    {% endif %}
+                                </td>
+                                <td>{{ page|default:"—" }}</td>
+                                {% if user.is_superuser or user|has_group:"Collection Managers" %}
+                                <td>{{ accession.accessioned_by|default_if_none:"—" }}</td>
+                                {% endif %}
+                            </tr>
+                            {% empty %}
+                            <tr>
+                                <td colspan="{% if user.is_superuser or user|has_group:"Collection Managers" %}7{% else %}6{% endif %}" class="w3-center">No accessions found.</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+
+
             </div>
         </div>
-<!--10.1016/j.jhevol.2008.02.001
-
- 
-
-https://doi.org/10.1016/j.jhevol.2008.02.001
-
-
-
-
--->
-{% endblock %}
+        {% endblock %}
 
 

--- a/app/cms/templates/cms/reference_list.html
+++ b/app/cms/templates/cms/reference_list.html
@@ -88,7 +88,16 @@
               {% endif %}
             </a>
           </th>
-          <th class="w3-center">Accessions</th>
+          <th class="w3-center">
+            <a href="?{% querystring_replace sort='accessions' direction=sort_directions|get_item:'accessions' page=None %}">
+              Accessions
+              {% if current_sort == 'accessions' %}
+                <i class="fa-solid {% if current_direction == 'asc' %}fa-sort-up{% else %}fa-sort-down{% endif %}"></i>
+              {% else %}
+                <i class="fa-solid fa-sort"></i>
+              {% endif %}
+            </a>
+          </th>
         </tr>
       </thead>
       <tbody>

--- a/app/cms/templates/cms/reference_list.html
+++ b/app/cms/templates/cms/reference_list.html
@@ -88,6 +88,7 @@
               {% endif %}
             </a>
           </th>
+          <th class="w3-center">Accessions</th>
         </tr>
       </thead>
       <tbody>
@@ -98,10 +99,11 @@
           </td>
           <td>{{ reference.year }}</td>
           <td>{{ reference.title }}</td>
+          <td class="w3-center">{{ reference.accession_count }}</td>
         </tr>
         {% empty %}
         <tr>
-          <td colspan="3" class="w3-center">No references found.</td>
+          <td colspan="4" class="w3-center">No references found.</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -970,6 +970,107 @@ class AccessionVisibilityTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+class ReferenceListViewTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.creator = User.objects.create_user(username="creator", password="pass")
+        self.collection_manager = User.objects.create_user(username="manager", password="pass")
+        self.cm_group = Group.objects.create(name="Collection Managers")
+        self.cm_group.user_set.add(self.collection_manager)
+
+        self.patcher = patch("cms.models.get_current_user", return_value=self.creator)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+        self.collection = Collection.objects.create(
+            abbreviation="COL",
+            description="Collection",
+        )
+        self.locality = Locality.objects.create(abbreviation="LOC", name="Locality")
+
+        self.reference_with_published = Reference.objects.create(
+            title="Published Reference",
+            first_author="Author Published",
+            year="2001",
+            citation="Citation Published",
+        )
+        self.reference_with_unpublished = Reference.objects.create(
+            title="Unpublished Reference",
+            first_author="Author Unpublished",
+            year="2002",
+            citation="Citation Unpublished",
+        )
+        self.reference_without_accessions = Reference.objects.create(
+            title="Orphan Reference",
+            first_author="Author Orphan",
+            year="2003",
+            citation="Citation Orphan",
+        )
+
+        self.published_accession = Accession.objects.create(
+            collection=self.collection,
+            specimen_prefix=self.locality,
+            specimen_no=1,
+        )
+        self.unpublished_accession = Accession.objects.create(
+            collection=self.collection,
+            specimen_prefix=self.locality,
+            specimen_no=2,
+        )
+
+        AccessionReference.objects.create(
+            accession=self.published_accession,
+            reference=self.reference_with_published,
+        )
+        AccessionReference.objects.create(
+            accession=self.unpublished_accession,
+            reference=self.reference_with_unpublished,
+        )
+
+        self.published_accession.refresh_from_db()
+        self.unpublished_accession.refresh_from_db()
+
+        Accession.objects.filter(pk=self.unpublished_accession.pk).update(is_published=False)
+        self.unpublished_accession.refresh_from_db()
+
+    def test_public_user_sees_only_references_with_published_accessions(self):
+        response = self.client.get(reverse("reference_list"))
+        self.assertEqual(response.status_code, 200)
+
+        page = response.context["page_obj"]
+        self.assertEqual(
+            [reference.pk for reference in page.object_list],
+            [self.reference_with_published.pk],
+        )
+        self.assertEqual(page.object_list[0].accession_count, 1)
+
+        self.assertContains(response, "<th class=\"w3-center\">Accessions</th>", html=True)
+        self.assertContains(response, self.reference_with_published.first_author)
+        self.assertNotContains(response, self.reference_with_unpublished.first_author)
+        self.assertNotContains(response, self.reference_without_accessions.first_author)
+
+    def test_collection_manager_sees_all_references_with_accession_counts(self):
+        self.client.login(username="manager", password="pass")
+        response = self.client.get(reverse("reference_list"))
+        self.assertEqual(response.status_code, 200)
+
+        page = response.context["page_obj"]
+        self.assertCountEqual(
+            [reference.pk for reference in page.object_list],
+            [
+                self.reference_with_published.pk,
+                self.reference_with_unpublished.pk,
+                self.reference_without_accessions.pk,
+            ],
+        )
+
+        accession_counts = {
+            reference.pk: reference.accession_count for reference in page.object_list
+        }
+        self.assertEqual(accession_counts[self.reference_with_published.pk], 1)
+        self.assertEqual(accession_counts[self.reference_with_unpublished.pk], 1)
+        self.assertEqual(accession_counts[self.reference_without_accessions.pk], 0)
+
 class PlaceModelTests(TestCase):
     def setUp(self):
         User = get_user_model()

--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -1017,6 +1017,11 @@ class ReferenceListViewTests(TestCase):
             specimen_prefix=self.locality,
             specimen_no=2,
         )
+        self.second_published_accession = Accession.objects.create(
+            collection=self.collection,
+            specimen_prefix=self.locality,
+            specimen_no=3,
+        )
 
         AccessionReference.objects.create(
             accession=self.published_accession,
@@ -1026,9 +1031,14 @@ class ReferenceListViewTests(TestCase):
             accession=self.unpublished_accession,
             reference=self.reference_with_unpublished,
         )
+        AccessionReference.objects.create(
+            accession=self.second_published_accession,
+            reference=self.reference_with_published,
+        )
 
         self.published_accession.refresh_from_db()
         self.unpublished_accession.refresh_from_db()
+        self.second_published_accession.refresh_from_db()
 
         Accession.objects.filter(pk=self.unpublished_accession.pk).update(is_published=False)
         self.unpublished_accession.refresh_from_db()
@@ -1042,9 +1052,12 @@ class ReferenceListViewTests(TestCase):
             [reference.pk for reference in page.object_list],
             [self.reference_with_published.pk],
         )
-        self.assertEqual(page.object_list[0].accession_count, 1)
+        self.assertEqual(page.object_list[0].accession_count, 2)
 
-        self.assertContains(response, "<th class=\"w3-center\">Accessions</th>", html=True)
+        self.assertContains(
+            response,
+            '<a href="?sort=accessions&amp;direction=asc"',
+        )
         self.assertContains(response, self.reference_with_published.first_author)
         self.assertNotContains(response, self.reference_with_unpublished.first_author)
         self.assertNotContains(response, self.reference_without_accessions.first_author)
@@ -1067,9 +1080,44 @@ class ReferenceListViewTests(TestCase):
         accession_counts = {
             reference.pk: reference.accession_count for reference in page.object_list
         }
-        self.assertEqual(accession_counts[self.reference_with_published.pk], 1)
+        self.assertEqual(accession_counts[self.reference_with_published.pk], 2)
         self.assertEqual(accession_counts[self.reference_with_unpublished.pk], 1)
         self.assertEqual(accession_counts[self.reference_without_accessions.pk], 0)
+
+    def test_collection_manager_can_sort_by_accession_count(self):
+        self.client.login(username="manager", password="pass")
+
+        response = self.client.get(
+            reverse("reference_list"), {"sort": "accessions", "direction": "desc"}
+        )
+        self.assertEqual(response.status_code, 200)
+
+        page = response.context["page_obj"]
+        self.assertEqual(
+            [reference.pk for reference in page.object_list],
+            [
+                self.reference_with_published.pk,
+                self.reference_with_unpublished.pk,
+                self.reference_without_accessions.pk,
+            ],
+        )
+        self.assertEqual(response.context["current_sort"], "accessions")
+        self.assertEqual(response.context["current_direction"], "desc")
+        self.assertEqual(response.context["sort_directions"]["accessions"], "asc")
+
+        response = self.client.get(
+            reverse("reference_list"), {"sort": "accessions", "direction": "asc"}
+        )
+
+        page = response.context["page_obj"]
+        self.assertEqual(
+            [reference.pk for reference in page.object_list],
+            [
+                self.reference_without_accessions.pk,
+                self.reference_with_unpublished.pk,
+                self.reference_with_published.pk,
+            ],
+        )
 
 class PlaceModelTests(TestCase):
     def setUp(self):

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -560,7 +560,12 @@ class AccessionDetailView(DetailView):
         context['references'] = AccessionReference.objects.filter(accession=self.object).select_related('reference')
         context['geologies'] = SpecimenGeology.objects.filter(accession=self.object)
         context['comments'] = Comment.objects.filter(specimen_no=self.object)
-        accession_rows = AccessionRow.objects.filter(accession=self.object)
+        accession_rows = AccessionRow.objects.filter(accession=self.object).prefetch_related(
+            Prefetch(
+                'natureofspecimen_set',
+                queryset=NatureOfSpecimen.objects.select_related('element'),
+            )
+        )
         # Form for adding existing FieldSlips
         context["add_fieldslip_form"] = AccessionFieldSlipForm()
 

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -846,6 +846,7 @@ class ReferenceListView(FilterView):
         "first_author": "first_author",
         "year": "year",
         "title": "title",
+        "accessions": "accession_count",
     }
     default_order = "first_author"
 

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -851,6 +851,21 @@ class ReferenceListView(FilterView):
 
     def get_queryset(self):
         queryset = super().get_queryset()
+        user = self.request.user
+
+        if is_public_user(user):
+            queryset = queryset.annotate(
+                accession_count=Count(
+                    "accessionreference",
+                    filter=Q(accessionreference__accession__is_published=True),
+                    distinct=True,
+                )
+            ).filter(accession_count__gt=0)
+        else:
+            queryset = queryset.annotate(
+                accession_count=Count("accessionreference", distinct=True)
+            )
+
         sort_key = self.request.GET.get("sort") or self.default_order
         direction = self.request.GET.get("direction", "asc")
 


### PR DESCRIPTION
## Summary
- group the primary place attributes into a single details card while keeping relation information separate
- combine the locality abbreviation and name into one card on the locality detail page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd2dd99e8883299d694a3e0f30392a