### PR TITLE
Normalize media ingest timestamps to Nairobi timezone

### DIFF
--- a/app/cms/scanning_utils.py
+++ b/app/cms/scanning_utils.py
@@ -1,0 +1,26 @@
+"""Utilities for normalising scanning-related timestamps."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+from zoneinfo import ZoneInfo
+
+from django.utils import timezone as django_timezone
+
+NAIROBI_TZ = ZoneInfo("Africa/Nairobi")
+
+
+def to_nairobi(value: datetime) -> datetime:
+    """Return ``value`` converted to the Africa/Nairobi timezone.
+
+    Naive datetimes are assumed to represent UTC instants, matching how
+    filesystem timestamps are stored. The result is always timezone-aware.
+    """
+
+    if django_timezone.is_naive(value):
+        value = value.replace(tzinfo=dt_timezone.utc)
+    return value.astimezone(NAIROBI_TZ)
+
+
+__all__ = ["NAIROBI_TZ", "to_nairobi"]
+


### PR DESCRIPTION
## Summary
- add a scanning_utils helper that normalizes datetimes to the Africa/Nairobi timezone
- update upload_processing.create_media to read filesystem timestamps as Nairobi-aware values before linking scans
- add a regression test covering UTC host timestamps to ensure media records attach to the correct scanning session

## Testing
- python app/manage.py test cms.tests

------
https://chatgpt.com/codex/tasks/task_e_68dcd94c7c3483298e4ea1bb264efeeb