### PR TITLE
Add QC summary diff helpers and enforce warning acknowledgements

### DIFF
--- a/app/cms/qc/__init__.py
+++ b/app/cms/qc/__init__.py
@@ -1,0 +1,17 @@
+"""Helper utilities for QC workflows."""
+
+from .diff import (
+    diff_media_payload,
+    ident_payload_has_meaningful_data,
+    interpreted_value,
+    iter_field_diffs,
+)
+from .preview import build_preview_accession
+
+__all__ = [
+    "diff_media_payload",
+    "ident_payload_has_meaningful_data",
+    "interpreted_value",
+    "iter_field_diffs",
+    "build_preview_accession",
+]

--- a/app/cms/qc/diff.py
+++ b/app/cms/qc/diff.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Iterator, List, Sequence, Tuple
+
+_METADATA_PREFIX = "_"
+
+
+def interpreted_value(value: Any) -> Any:
+    """Return the interpreted value from OCR payload entries."""
+
+    if isinstance(value, dict):
+        if "interpreted" in value:
+            return value.get("interpreted")
+        return None
+    return value
+
+
+def ident_payload_has_meaningful_data(entry: dict | None) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    for key in (
+        "taxon",
+        "identification_qualifier",
+        "verbatim_identification",
+        "identification_remarks",
+        "identified_by",
+        "reference",
+        "date_identified",
+    ):
+        if interpreted_value(entry.get(key)) not in (None, ""):
+            return True
+    return False
+
+
+def _is_metadata_key(key: str | None) -> bool:
+    return bool(key) and key.startswith(_METADATA_PREFIX)
+
+
+def _strip_metadata(payload: Any) -> Any:
+    if isinstance(payload, dict):
+        return {
+            key: _strip_metadata(value)
+            for key, value in payload.items()
+            if not _is_metadata_key(key)
+        }
+    if isinstance(payload, list):
+        return [_strip_metadata(value) for value in payload]
+    return payload
+
+
+def iter_field_diffs(old: Any, new: Any, path: str = "") -> Iterator[Tuple[str, Any, Any]]:
+    """Yield differences between two payload structures."""
+
+    if isinstance(new, dict) and not isinstance(old, dict):
+        old = {}
+    if isinstance(new, list) and not isinstance(old, list):
+        old = []
+
+    if isinstance(old, dict) and isinstance(new, dict):
+        keys = set(old.keys()) | set(new.keys())
+        for key in sorted(keys):
+            if _is_metadata_key(key):
+                continue
+            if key == "interpreted":
+                old_val = old.get("interpreted")
+                new_val = new.get("interpreted")
+                if old_val != new_val:
+                    yield path, old_val, new_val
+                continue
+            sub_path = f"{path}.{key}" if path else key
+            yield from iter_field_diffs(old.get(key), new.get(key), sub_path)
+    elif isinstance(old, list) and isinstance(new, list):
+        length = max(len(old), len(new))
+        for index in range(length):
+            old_value = old[index] if index < len(old) else None
+            new_value = new[index] if index < len(new) else None
+            sub_path = f"{path}[{index}]" if path else f"[{index}]"
+            yield from iter_field_diffs(old_value, new_value, sub_path)
+    else:
+        if old != new:
+            yield path, old, new
+
+
+@dataclass(frozen=True)
+class _CountDiff:
+    key: str
+    label: str
+    original: int
+    current: int
+
+    @property
+    def changed(self) -> bool:
+        return self.original != self.current
+
+    @property
+    def delta(self) -> int:
+        return self.current - self.original
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "label": self.label,
+            "original": self.original,
+            "current": self.current,
+            "changed": self.changed,
+            "delta": self.delta,
+        }
+
+
+def _get_accession_payload(data: dict | None) -> dict:
+    if not isinstance(data, dict):
+        return {}
+    accessions = data.get("accessions")
+    if isinstance(accessions, list) and accessions:
+        first = accessions[0]
+        if isinstance(first, dict):
+            return first
+    return {}
+
+
+def _list_or_empty(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _row_key(row: dict | None, index: int) -> str:
+    if not isinstance(row, dict):
+        return f"index::{index}"
+    for key_name in ("_row_id", "row_id"):
+        value = row.get(key_name)
+        if value not in (None, ""):
+            return str(value)
+    suffix = interpreted_value(row.get("specimen_suffix"))
+    if suffix not in (None, ""):
+        return f"suffix::{suffix}"
+    return f"index::{index}"
+
+
+def _row_has_meaningful_data(row: dict | None) -> bool:
+    if not isinstance(row, dict):
+        return False
+    if interpreted_value(row.get("specimen_suffix")) not in (None, "", "-"):
+        return True
+    if interpreted_value(row.get("storage_area")) not in (None, ""):
+        return True
+    natures = _list_or_empty(row.get("natures"))
+    for nature in natures:
+        if not isinstance(nature, dict):
+            continue
+        for key in (
+            "element_name",
+            "side",
+            "condition",
+            "verbatim_element",
+            "portion",
+            "fragments",
+        ):
+            if interpreted_value(nature.get(key)) not in (None, ""):
+                return True
+    return False
+
+
+def _count_rows(rows: Sequence[dict]) -> int:
+    return len(rows)
+
+
+def _count_identifications(entries: Sequence[dict]) -> int:
+    return sum(1 for entry in entries if ident_payload_has_meaningful_data(entry))
+
+
+def _count_specimens(rows: Sequence[dict]) -> int:
+    total = 0
+    for row in rows:
+        natures = _list_or_empty(row.get("natures"))
+        total += sum(1 for nature in natures if isinstance(nature, dict))
+    return total
+
+
+def _entry_has_meaningful_data(entry: dict | None, keys: Iterable[str]) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    return any(interpreted_value(entry.get(key)) not in (None, "") for key in keys)
+
+
+def _count_references(entries: Sequence[dict]) -> int:
+    return sum(
+        1
+        for entry in entries
+        if _entry_has_meaningful_data(
+            entry,
+            ("reference_first_author", "reference_title", "reference_year", "page"),
+        )
+    )
+
+
+def _count_field_slips(entries: Sequence[dict]) -> int:
+    return sum(
+        1
+        for entry in entries
+        if _entry_has_meaningful_data(
+            entry,
+            (
+                "field_number",
+                "verbatim_locality",
+                "verbatim_taxon",
+                "verbatim_element",
+                "aerial_photo",
+                "verbatim_latitude",
+                "verbatim_longitude",
+                "verbatim_elevation",
+            ),
+        )
+        or _entry_has_meaningful_data(
+            entry.get("verbatim_horizon"),
+            ("formation", "member", "bed_or_horizon", "chronostratigraphy"),
+        )
+    )
+
+
+def _build_count_diffs(original_payload: dict, current_payload: dict) -> List[dict[str, Any]]:
+    original_rows = _list_or_empty(original_payload.get("rows"))
+    current_rows = _list_or_empty(current_payload.get("rows"))
+    original_idents = _list_or_empty(original_payload.get("identifications"))
+    current_idents = _list_or_empty(current_payload.get("identifications"))
+    original_refs = _list_or_empty(original_payload.get("references"))
+    current_refs = _list_or_empty(current_payload.get("references"))
+    original_field_slips = _list_or_empty(original_payload.get("field_slips"))
+    current_field_slips = _list_or_empty(current_payload.get("field_slips"))
+
+    diffs = [
+        _CountDiff(
+            key="rows",
+            label="Specimen rows",
+            original=_count_rows(original_rows),
+            current=_count_rows(current_rows),
+        ),
+        _CountDiff(
+            key="identifications",
+            label="Identifications",
+            original=_count_identifications(original_idents),
+            current=_count_identifications(current_idents),
+        ),
+        _CountDiff(
+            key="specimens",
+            label="Specimen records",
+            original=_count_specimens(original_rows),
+            current=_count_specimens(current_rows),
+        ),
+        _CountDiff(
+            key="references",
+            label="References",
+            original=_count_references(original_refs),
+            current=_count_references(current_refs),
+        ),
+        _CountDiff(
+            key="field_slips",
+            label="Field slips",
+            original=_count_field_slips(original_field_slips),
+            current=_count_field_slips(current_field_slips),
+        ),
+    ]
+    return [diff.as_dict() for diff in diffs]
+
+
+def _detect_rows_reordered(original_payload: dict, current_payload: dict) -> bool:
+    original_rows = _list_or_empty(original_payload.get("rows"))
+    current_rows = _list_or_empty(current_payload.get("rows"))
+    original_keys = [_row_key(row, index) for index, row in enumerate(original_rows)]
+    current_keys = [_row_key(row, index) for index, row in enumerate(current_rows)]
+
+    filtered_current = [key for key in current_keys if key in original_keys]
+    trimmed_original = original_keys[: len(filtered_current)]
+    return filtered_current != trimmed_original and bool(filtered_current)
+
+
+def _detect_removed_identifications(
+    original_payload: dict, current_payload: dict
+) -> List[dict[str, Any]]:
+    original_rows = _list_or_empty(original_payload.get("rows"))
+    current_rows = _list_or_empty(current_payload.get("rows"))
+    original_identifications = _list_or_empty(original_payload.get("identifications"))
+
+    removed_indexes: List[int] = []
+    if len(original_identifications) > len(current_rows):
+        for index in range(len(current_rows), len(original_identifications)):
+            if ident_payload_has_meaningful_data(original_identifications[index]):
+                removed_indexes.append(index)
+
+    if not removed_indexes:
+        return []
+
+    count = len(removed_indexes)
+    message = (
+        "{} identification record{} no longer match a specimen row.".format(
+            count, "s" if count != 1 else ""
+        )
+    )
+    return [
+        {
+            "code": "unlinked_identifications",
+            "label": "Unlinked identifications",
+            "count": count,
+            "message": message,
+        }
+    ]
+
+
+def diff_media_payload(
+    original: dict | None,
+    current: dict | None,
+    *,
+    rows_reordered: bool | None = None,
+) -> dict[str, Any]:
+    """Return a rich diff summary between two media payloads."""
+
+    original = original or {}
+    current = current or {}
+
+    stripped_original = _strip_metadata(original)
+    stripped_current = _strip_metadata(current)
+
+    original_accession = _get_accession_payload(stripped_original)
+    current_accession = _get_accession_payload(stripped_current)
+
+    field_diffs = list(iter_field_diffs(stripped_original, stripped_current))
+    if rows_reordered is None:
+        rows_reordered = _detect_rows_reordered(original_accession, current_accession)
+
+    count_diffs = _build_count_diffs(original_accession, current_accession)
+    warnings: List[dict[str, Any]] = _detect_removed_identifications(
+        original_accession, current_accession
+    )
+
+    return {
+        "field_diffs": field_diffs,
+        "rows_reordered": bool(rows_reordered),
+        "count_diffs": count_diffs,
+        "warnings": warnings,
+    }

--- a/app/cms/qc/preview.py
+++ b/app/cms/qc/preview.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+from django.contrib.auth import get_user_model
+
+from cms.models import Collection, Locality, Taxon
+
+from .diff import ident_payload_has_meaningful_data, interpreted_value
+
+User = get_user_model()
+
+
+class PreviewMediaRelation:
+    def all(self) -> list:
+        return []
+
+
+@dataclass
+class PreviewTaxonomy:
+    family: Optional[str] = None
+    subfamily: Optional[str] = None
+    tribe: Optional[str] = None
+    genus: Optional[str] = None
+    species: Optional[str] = None
+
+
+@dataclass
+class PreviewNature:
+    element: Optional[str]
+    side: Optional[str]
+    condition: Optional[str]
+    verbatim_element: Optional[str]
+    portion: Optional[str]
+    fragments: Optional[str]
+
+
+class PreviewNatureManager:
+    def __init__(self, items: Iterable[PreviewNature]):
+        self._items = list(items)
+
+    def all(self) -> List[PreviewNature]:
+        return list(self._items)
+
+
+@dataclass
+class PreviewAccessionRow:
+    id: str
+    specimen_suffix: Optional[str]
+    storage: Optional[str]
+    natureofspecimen_set: PreviewNatureManager
+
+
+@dataclass
+class PreviewIdentification:
+    id: str
+    taxon: Optional[str]
+    identification_qualifier: Optional[str]
+    verbatim_identification: Optional[str]
+    identification_remarks: Optional[str]
+
+
+class PreviewAccession:
+    def __init__(
+        self,
+        collection_abbr: Optional[str],
+        prefix_obj: Optional[Locality | str],
+        specimen_no: Optional[int | str],
+        type_status: Optional[str],
+        comment: Optional[str],
+        accessioned_by: Optional[User],
+    ) -> None:
+        self.collection_abbr = collection_abbr or ""
+        self.specimen_prefix = prefix_obj
+        self.specimen_no = specimen_no
+        self.type_status = type_status
+        self.comment = comment
+        self.accessioned_by = accessioned_by
+        self.media = PreviewMediaRelation()
+        self.instance_number = 1
+
+    def __str__(self) -> str:
+        prefix_display = str(self.specimen_prefix or "")
+        specimen_value = self.specimen_no or ""
+        base = f"{self.collection_abbr}-{prefix_display} {specimen_value}".strip()
+        return base or "Preview accession"
+
+
+def _get_accession_payload(data: dict | None) -> dict:
+    if not isinstance(data, dict):
+        return {}
+    accessions = data.get("accessions")
+    if isinstance(accessions, list) and accessions:
+        first = accessions[0]
+        if isinstance(first, dict):
+            return first
+    return {}
+
+
+def _build_preview_rows(payload: dict) -> tuple[List[PreviewAccessionRow], Dict[str, PreviewIdentification], Dict[str, int], Dict[str, object]]:
+    rows_payload = payload.get("rows") or []
+    ident_payload = payload.get("identifications") or []
+
+    rows: List[PreviewAccessionRow] = []
+    first_identifications: Dict[str, PreviewIdentification] = {}
+    identification_counts: Dict[str, int] = {}
+    taxonomy_map: Dict[str, object] = {}
+
+    for index, row in enumerate(rows_payload):
+        if not isinstance(row, dict):
+            continue
+        row_id = str(row.get("_row_id") or row.get("row_id") or f"row-{index}")
+        specimen_suffix = interpreted_value(row.get("specimen_suffix"))
+        storage = interpreted_value(row.get("storage_area"))
+        natures_payload = row.get("natures") or []
+        natures: List[PreviewNature] = []
+        for nature in natures_payload:
+            if not isinstance(nature, dict):
+                continue
+            natures.append(
+                PreviewNature(
+                    element=interpreted_value(nature.get("element_name")),
+                    side=interpreted_value(nature.get("side")),
+                    condition=interpreted_value(nature.get("condition")),
+                    verbatim_element=interpreted_value(nature.get("verbatim_element")),
+                    portion=interpreted_value(nature.get("portion")),
+                    fragments=interpreted_value(nature.get("fragments")),
+                )
+            )
+        row_obj = PreviewAccessionRow(
+            id=row_id,
+            specimen_suffix=specimen_suffix,
+            storage=storage,
+            natureofspecimen_set=PreviewNatureManager(natures),
+        )
+        rows.append(row_obj)
+
+        ident_entry = ident_payload[index] if index < len(ident_payload) else {}
+        if ident_payload_has_meaningful_data(ident_entry):
+            ident_obj = PreviewIdentification(
+                id=f"{row_id}-ident",
+                taxon=interpreted_value(ident_entry.get("taxon")),
+                identification_qualifier=interpreted_value(ident_entry.get("identification_qualifier")),
+                verbatim_identification=interpreted_value(ident_entry.get("verbatim_identification")),
+                identification_remarks=interpreted_value(ident_entry.get("identification_remarks")),
+            )
+            first_identifications[row_id] = ident_obj
+            identification_counts[row_id] = 1
+            taxon_name = ident_obj.taxon
+            if taxon_name:
+                taxonomy_map[ident_obj.id] = (
+                    Taxon.objects.filter(taxon_name__iexact=taxon_name).first()
+                    or PreviewTaxonomy()
+                )
+            else:
+                taxonomy_map[ident_obj.id] = PreviewTaxonomy()
+        else:
+            identification_counts[row_id] = 0
+
+    return rows, first_identifications, identification_counts, taxonomy_map
+
+
+def _build_preview_references(payload: dict) -> List[object]:
+    references_payload = payload.get("references") or []
+    references: List[object] = []
+    for entry in references_payload:
+        if not isinstance(entry, dict):
+            continue
+        reference = type(
+            "PreviewReferenceDetails",
+            (),
+            {
+                "year": interpreted_value(entry.get("reference_year")),
+                "first_author": interpreted_value(entry.get("reference_first_author")),
+                "title": interpreted_value(entry.get("reference_title")),
+            },
+        )()
+        record = type(
+            "PreviewReference",
+            (),
+            {
+                "reference": reference,
+                "page": interpreted_value(entry.get("page")),
+            },
+        )()
+        references.append(record)
+    return references
+
+
+def _resolve_prefix(abbreviation: Optional[str]) -> Optional[object]:
+    if not abbreviation:
+        return None
+    locality = Locality.objects.filter(abbreviation=abbreviation).first()
+    if locality:
+        return locality
+    return abbreviation
+
+
+def _resolve_collection_abbr(abbreviation: Optional[str]) -> Optional[str]:
+    if not abbreviation:
+        return None
+    collection = Collection.objects.filter(abbreviation=abbreviation).first()
+    if collection:
+        return collection.abbreviation
+    return abbreviation
+
+
+def _resolve_accessioned_by(form, request_user) -> Optional[User]:
+    if form is not None:
+        if hasattr(form, "is_valid") and form.is_bound and form.is_valid():
+            value = form.cleaned_data.get("accessioned_by")
+            if value:
+                return value
+        initial = getattr(form, "initial", {}) or {}
+        value = initial.get("accessioned_by")
+        if value:
+            return value
+    return request_user if isinstance(request_user, User) else None
+
+
+def build_preview_accession(
+    payload: dict | None,
+    accession_form=None,
+    *,
+    request_user=None,
+) -> dict[str, object]:
+    accession_payload = _get_accession_payload(payload)
+
+    collection_abbr = interpreted_value(accession_payload.get("collection_abbreviation"))
+    prefix_abbr = interpreted_value(accession_payload.get("specimen_prefix_abbreviation"))
+    specimen_no = interpreted_value(accession_payload.get("specimen_no"))
+    type_status = interpreted_value(accession_payload.get("type_status"))
+    comment = interpreted_value(accession_payload.get("comment"))
+
+    try:
+        specimen_no_display = int(specimen_no)
+    except (TypeError, ValueError):
+        specimen_no_display = specimen_no
+
+    accessioned_by = _resolve_accessioned_by(accession_form, request_user)
+
+    accession_obj = PreviewAccession(
+        collection_abbr=_resolve_collection_abbr(collection_abbr),
+        prefix_obj=_resolve_prefix(prefix_abbr),
+        specimen_no=specimen_no_display,
+        type_status=type_status,
+        comment=comment,
+        accessioned_by=accessioned_by,
+    )
+
+    rows, first_identifications, identification_counts, taxonomy_map = _build_preview_rows(
+        accession_payload
+    )
+    references = _build_preview_references(accession_payload)
+
+    return {
+        "accession": accession_obj,
+        "geologies": [],
+        "accession_rows": rows,
+        "first_identifications": first_identifications,
+        "identification_counts": identification_counts,
+        "taxonomy": taxonomy_map,
+        "references": references,
+    }

--- a/app/cms/templates/cms/accession_detail.html
+++ b/app/cms/templates/cms/accession_detail.html
@@ -14,223 +14,10 @@
             </a>
             {% endif %}
         </div>
-        <div class="grid-containerr">            
-            <!-- Accession Card -->            
+        {% include "cms/partials/accession_preview_panel.html" with preview_mode=False %}
+        <div class="grid-containerr">
             <div class="cards">
-                <table>
-                    <caption><b><u>Accession</u></b></caption>
-                    <tbody>
-                        <tr>
-                            <th>ACC No.:</th>
-                            <td>{{ accession }}</td>
-                        </tr>
-                        <tr>
-                            <th>Locality:</th>
-                            <td>{{ accession.specimen_prefix }}</td>
-                        </tr>
-                        <tr>
-                            <th>Type specimen:</th>
-                            <td>{{ accession.type_status }}</td>
-                        </tr>
-                        {% if user.is_superuser or user|has_group:"Collection Managers" %}
-                        <tr>
-                            <th>Accessioned by:</th>
-                            <td>{{ accession.accessioned_by }}</td>
-                        </tr>
-                        {% endif %}
-                        <tr>
-                            <th>General comment:</th>
-                            <td>{{ accession.comment }}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="cards">
-
-                {% if user.is_authenticated and user|has_group:"Collection Managers" %}
-                    <a href="{% url 'accession_add_geology' accession.id %}">➕ Add Horizon</a>
-                {% endif %}
-
-                <table>
-                    <caption><b><u>Horizon</u></b></caption>
-                    <thead>
-                        <tr>
-                            <th>Upper</th>
-                            <th>Lower</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for geology in geologies %}                   
-                            <tr>
-                                <td>{{ geology.earliest_geological_context }}</td>
-                                <td>{{ geology.latest_geological_context }}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-                
                 <hr class="accession_hr">
-                {% if user.is_authenticated and user|has_group:"Collection Managers" %}
-                    <a href="{% url 'accession_add_row' accession.id %}">➕ Add Specimen</a>
-                {% endif %}
-                <table>
-                    <caption><em>Specimen details</em></caption>
-                    <thead>
-                        <tr>
-                            <th>Specimen</th>
-                            <th>Storage</th>
-                            <th>Element</th>
-                            <th>Side</th>
-                            <th>Description</th>
-                            <th>Taxon</th>
-                            <th>Family</th>
-                            <th>Subfamily</th>
-                            <th>Tribe</th>
-                            <th>Genus</th>
-                            <th>Species</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for accessionrow in accession_rows %}
-                            {% with specimens=accessionrow.natureofspecimen_set.all %}
-                            <tr>
-                                <td><a href="{% url 'accessionrow_detail' accessionrow.pk %}">{{ accessionrow.specimen_suffix }}</a></td>
-                                <td>{{ accessionrow.storage }}</td>
-                                <td>
-                                    {% if specimens %}
-                                        {% for specimen in specimens %}
-                                            {{ specimen.element|default:"—" }}{% if not forloop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    {% else %}
-                                        &mdash;
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if specimens %}
-                                        {% for specimen in specimens %}
-                                            {{ specimen.side|default:"—" }}{% if not forloop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    {% else %}
-                                        &mdash;
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    {% if specimens %}
-                                        {% for specimen in specimens %}
-                                            {{ specimen.verbatim_element|default:"—" }}{% if not forloop.last %}<br>{% endif %}
-                                        {% endfor %}
-                                    {% else %}
-                                        &mdash;
-                                    {% endif %}
-                                </td>
-
-                                {% with first_identifications|get_item:accessionrow.id as first_identification %}
-                                    {% if first_identification %}
-                                        {% with taxonomy|get_item:first_identification.id as matched_taxon %}
-                                            <td>
-                                                {{ first_identification.taxon }}
-                                                {% if identification_counts|get_item:accessionrow.id > 1 %}
-                                                    <span title="This specimen has previous identifications">(*)</span>
-                                                {% endif %}
-                                            </td>
-                                            <td>{{ matched_taxon.family|default:"-" }}</td>
-                                            <td>{{ matched_taxon.subfamily|default:"-" }}</td>
-                                            <td>{{ matched_taxon.tribe|default:"-" }}</td>
-                                            <td>{{ matched_taxon.genus|default:"-" }}</td>
-                                            <td>{{ matched_taxon.species|default:"-" }}</td>
-                                        {% endwith %}
-                                    {% else %}
-                                        <td>No Taxon identified</td>
-                                        <td>-</td>
-                                        <td>-</td>
-                                        <td>-</td>
-                                        <td>-</td>
-                                        <td>-</td>
-                                    {% endif %}
-                                {% endwith %}
-                            </tr>
-                            {% endwith %}
-                        {% endfor %}
-                    </tbody>
-                </table>
-                <hr class="accession_hr">
-                {% if user.is_authenticated and user|has_group:"Collection Managers" %}
-                  <a href="{% url 'accession_add_reference' accession.id %}">➕ Add Reference</a>
-                {% endif %}
-                {% if references %}
-                <table>
-                    <caption>References</caption>
-                    <thead>
-                        <tr>
-                            <th>Year</th>
-                            <th>First author</th>
-                            <th>Title</th>
-                            <th>Page(s)</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for ref in references %}
-                            <tr>
-                                <td>{{ ref.reference.year }}</td>
-                                <td>{{ ref.reference.first_author }}</td>
-                                <td>{{ ref.reference.title }}</td>
-                                <td>{{ ref.page }}</td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                    <tfoot>
-                        <tr>
-                            <td colspan="3"> {{ references|length }} References</td>
-                        </tr>
-                    </tfoot>
-                </table>
-                {% else %}
-                    <p>No References found for this accession.</p>
-                {% endif %}
-                <hr class="accession_hr">                
-
-                {% if user.is_authenticated and user|has_group:"Collection Managers" %}
-                    <a href="{% url 'accession_upload_media' accession.id %}">➕ Upload Media</a>
-                {% endif %}
-                <table>
-                    <caption><em>Media</em></caption>
-                    <thead>
-                    <tr>
-                        <th>File Name</th>
-                        <th>Type</th>
-                        <th>License</th>
-                        <th>Media</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {% if accession.media.all %}
-                        {% for media in accession.media.all %}
-                            <tr>
-                                <td>{{ media.file_name }}</td>
-                                <td>{{ media.type }}</td>
-                                <td>{{ media.get_license_display }}</td>
-                                <td>
-                                    {% if media.media_location %}
-                                        <a href="{{ media.media_location.url }}" target="_blank">
-                                        {% if media.type == "photo" %}
-                                            <img src="{{ media.media_location.url }}" alt="{{ media.file_name }}" height="100">
-                                        {% else %}
-                                            View File
-                                        {% endif %}
-                                        </a>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    {% else %}
-                        <tr>
-                            <td>There are no media files available for this accession.</td>
-                        </tr>
-                    {% endif %}
-                    </tbody>
-                </table>
-                <hr class="accession_hr">
-
                 {% if user.is_authenticated and user|has_group:"Collection Managers" %}
                   <a href="{% url 'accession_add_comment' accession.id %}">➕ Add Comment</a>
                 {% endif %}
@@ -258,11 +45,10 @@
                     </table>
                 {% else %}
                     <p>No Comments found for this accession.</p>
-                {% endif %}            
+                {% endif %}
             </div>
             {% if user.is_superuser or user|has_group:"Collection Managers" %}
             <div class="cards">
-
                 <table class="table">
                     <caption><b><u>Related FieldSlips</u></b></caption>
                     <thead>
@@ -290,7 +76,7 @@
                         {% endfor %}
                     </tbody>
                 </table>
-            
+
                 <h5><strong><u>Add Existing FieldSlip</u></strong></h5>
                 {{ add_fieldslip_form.media }}
                 <form method="POST" action="{% url 'accession_add_fieldslip' accession.pk %}">
@@ -302,7 +88,7 @@
 
                 <!-- Button to open the modal -->
                 <button onclick="openFieldSlipModal()" class="accesssin_FieldSlip">➕ Add a New FieldSlip</button>
-                
+
                 <!-- Modal (hidden by default) -->
                 <div id="fieldSlipModal" class="w3-modal">
                     <div class="w3-modal-content w3-card-4 w3-animate-top" style="max-width: 800px;">

--- a/app/cms/templates/cms/partials/accession_preview_panel.html
+++ b/app/cms/templates/cms/partials/accession_preview_panel.html
@@ -1,4 +1,4 @@
-{% load custom_filters %}
+{% load custom_filters user_tags %}
 <div class="grid-containerr">
   <div class="cards">
     <table>

--- a/app/cms/templates/cms/partials/accession_preview_panel.html
+++ b/app/cms/templates/cms/partials/accession_preview_panel.html
@@ -1,0 +1,232 @@
+{% load custom_filters %}
+<div class="grid-containerr">
+  <div class="cards">
+    <table>
+      <caption><b><u>Accession</u></b></caption>
+      <tbody>
+        <tr>
+          <th>ACC No.:</th>
+          <td>{{ accession }}</td>
+        </tr>
+        <tr>
+          <th>Locality:</th>
+          <td>{{ accession.specimen_prefix }}</td>
+        </tr>
+        <tr>
+          <th>Type specimen:</th>
+          <td>{{ accession.type_status }}</td>
+        </tr>
+        {% if not preview_mode and (user.is_superuser or user|has_group:"Collection Managers") %}
+        <tr>
+          <th>Accessioned by:</th>
+          <td>{{ accession.accessioned_by }}</td>
+        </tr>
+        {% endif %}
+        <tr>
+          <th>General comment:</th>
+          <td>{{ accession.comment }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="cards">
+    {% if not preview_mode and user.is_authenticated and user|has_group:"Collection Managers" %}
+      <a href="{% url 'accession_add_geology' accession.id %}">➕ Add Horizon</a>
+    {% endif %}
+    <table>
+      <caption><b><u>Horizon</u></b></caption>
+      <thead>
+        <tr>
+          <th>Upper</th>
+          <th>Lower</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for geology in geologies %}
+          <tr>
+            <td>{{ geology.earliest_geological_context }}</td>
+            <td>{{ geology.latest_geological_context }}</td>
+          </tr>
+        {% empty %}
+          <tr>
+            <td colspan="2">No horizon data recorded.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <hr class="accession_hr">
+
+    {% if not preview_mode and user.is_authenticated and user|has_group:"Collection Managers" %}
+      <a href="{% url 'accession_add_row' accession.id %}">➕ Add Specimen</a>
+    {% endif %}
+    <table>
+      <caption><em>Specimen details</em></caption>
+      <thead>
+        <tr>
+          <th>Specimen</th>
+          <th>Storage</th>
+          <th>Element</th>
+          <th>Side</th>
+          <th>Description</th>
+          <th>Taxon</th>
+          <th>Family</th>
+          <th>Subfamily</th>
+          <th>Tribe</th>
+          <th>Genus</th>
+          <th>Species</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for accessionrow in accession_rows %}
+          {% with specimens=accessionrow.natureofspecimen_set.all %}
+          <tr>
+            <td>
+              {% if preview_mode %}
+                {{ accessionrow.specimen_suffix }}
+              {% else %}
+                <a href="{% url 'accessionrow_detail' accessionrow.pk %}">{{ accessionrow.specimen_suffix }}</a>
+              {% endif %}
+            </td>
+            <td>{{ accessionrow.storage }}</td>
+            <td>
+              {% if specimens %}
+                {% for specimen in specimens %}
+                  {{ specimen.element|default:"—" }}{% if not forloop.last %}<br>{% endif %}
+                {% endfor %}
+              {% else %}
+                &mdash;
+              {% endif %}
+            </td>
+            <td>
+              {% if specimens %}
+                {% for specimen in specimens %}
+                  {{ specimen.side|default:"—" }}{% if not forloop.last %}<br>{% endif %}
+                {% endfor %}
+              {% else %}
+                &mdash;
+              {% endif %}
+            </td>
+            <td>
+              {% if specimens %}
+                {% for specimen in specimens %}
+                  {{ specimen.verbatim_element|default:"—" }}{% if not forloop.last %}<br>{% endif %}
+                {% endfor %}
+              {% else %}
+                &mdash;
+              {% endif %}
+            </td>
+            {% with first_identifications|get_item:accessionrow.id as first_identification %}
+              {% if first_identification %}
+                {% with taxonomy|get_item:first_identification.id as matched_taxon %}
+                  <td>
+                    {{ first_identification.taxon }}
+                    {% if identification_counts|get_item:accessionrow.id > 1 %}
+                      <span title="This specimen has previous identifications">(*)</span>
+                    {% endif %}
+                  </td>
+                  <td>{{ matched_taxon.family|default:"-" }}</td>
+                  <td>{{ matched_taxon.subfamily|default:"-" }}</td>
+                  <td>{{ matched_taxon.tribe|default:"-" }}</td>
+                  <td>{{ matched_taxon.genus|default:"-" }}</td>
+                  <td>{{ matched_taxon.species|default:"-" }}</td>
+                {% endwith %}
+              {% else %}
+                <td>No Taxon identified</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+                <td>-</td>
+              {% endif %}
+            {% endwith %}
+          </tr>
+          {% endwith %}
+        {% empty %}
+          <tr>
+            <td colspan="11">No specimen rows recorded.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+    <hr class="accession_hr">
+
+    {% if not preview_mode and user.is_authenticated and user|has_group:"Collection Managers" %}
+      <a href="{% url 'accession_add_reference' accession.id %}">➕ Add Reference</a>
+    {% endif %}
+    {% if references %}
+      <table>
+        <caption>References</caption>
+        <thead>
+          <tr>
+            <th>Year</th>
+            <th>First author</th>
+            <th>Title</th>
+            <th>Page(s)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for ref in references %}
+            <tr>
+              <td>{{ ref.reference.year }}</td>
+              <td>{{ ref.reference.first_author }}</td>
+              <td>{{ ref.reference.title }}</td>
+              <td>{{ ref.page }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="3">{{ references|length }} References</td>
+          </tr>
+        </tfoot>
+      </table>
+    {% else %}
+      <p>No References found for this accession.</p>
+    {% endif %}
+
+    <hr class="accession_hr">
+
+    {% if not preview_mode and user.is_authenticated and user|has_group:"Collection Managers" %}
+      <a href="{% url 'accession_upload_media' accession.id %}">➕ Upload Media</a>
+    {% endif %}
+    <table>
+      <caption><em>Media</em></caption>
+      <thead>
+        <tr>
+          <th>File Name</th>
+          <th>Type</th>
+          <th>License</th>
+          <th>Media</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% if accession.media.all %}
+          {% for media in accession.media.all %}
+            <tr>
+              <td>{{ media.file_name }}</td>
+              <td>{{ media.type }}</td>
+              <td>{{ media.get_license_display }}</td>
+              <td>
+                {% if media.media_location %}
+                  <a href="{{ media.media_location.url }}" target="_blank">
+                    {% if media.type == "photo" %}
+                      <img src="{{ media.media_location.url }}" alt="{{ media.file_name }}" height="100">
+                    {% else %}
+                      View File
+                    {% endif %}
+                  </a>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        {% else %}
+          <tr>
+            <td colspan="4">There are no media files available for this accession.</td>
+          </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/cms/templates/cms/partials/accession_preview_panel.html
+++ b/app/cms/templates/cms/partials/accession_preview_panel.html
@@ -16,11 +16,13 @@
           <th>Type specimen:</th>
           <td>{{ accession.type_status }}</td>
         </tr>
-        {% if not preview_mode and (user.is_superuser or user|has_group:"Collection Managers") %}
+        {% if not preview_mode %}
+          {% if user.is_superuser or user|has_group:"Collection Managers" %}
         <tr>
           <th>Accessioned by:</th>
           <td>{{ accession.accessioned_by }}</td>
         </tr>
+          {% endif %}
         {% endif %}
         <tr>
           <th>General comment:</th>

--- a/app/cms/templates/cms/qc/summary_step.html
+++ b/app/cms/templates/cms/qc/summary_step.html
@@ -1,0 +1,44 @@
+{% if qc_diff %}
+<section class="qc-section qc-summary">
+  <div class="qc-section-heading w3-border-bottom w3-padding-small">
+    <h3>Summary</h3>
+    <span class="qc-inline-note">Compare your edits against the original OCR snapshot.</span>
+  </div>
+  <div class="qc-summary-grid">
+    {% for diff in qc_diff.count_diffs %}
+      <div class="qc-summary-card{% if diff.changed %} qc-summary-card--changed{% endif %}">
+        <span class="qc-summary-label">{{ diff.label }}</span>
+        <span class="qc-summary-value">{{ diff.current }}</span>
+        {% if diff.changed %}
+          <span class="qc-summary-delta">Original: {{ diff.original }}</span>
+        {% endif %}
+      </div>
+    {% empty %}
+      <p class="qc-inline-note">No totals were detected for this accession.</p>
+    {% endfor %}
+  </div>
+  {% if qc_diff.rows_reordered %}
+    <div class="w3-panel w3-pale-yellow w3-border">
+      Specimen rows were reordered. Confirm the new ordering matches the accession card before approving.
+    </div>
+  {% endif %}
+  {% if qc_diff.warnings %}
+    <div class="w3-panel w3-pale-red w3-border">
+      <h4 class="w3-margin-top w3-margin-bottom">Warnings</h4>
+      <ul class="qc-warning-list">
+        {% for warning in qc_diff.warnings %}
+          <li>{{ warning.message }}</li>
+        {% endfor %}
+      </ul>
+      <div class="qc-warning-ack-container">
+        {% for warning in qc_diff.warnings %}
+          <label class="qc-warning-ack">
+            <input type="checkbox" name="acknowledge_warnings" value="{{ warning.code }}"{% if warning.code in qc_acknowledged_warnings %} checked{% endif %}>
+            I have reviewed the {{ warning.label|lower }}.
+          </label>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
+</section>
+{% endif %}

--- a/app/cms/templates/cms/qc/wizard_base.html
+++ b/app/cms/templates/cms/qc/wizard_base.html
@@ -322,6 +322,61 @@
     .qc-row-card.is-dragging {
       opacity: 0.5;
     }
+    .qc-summary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+    .qc-summary-card {
+      border: 1px solid #dcdcdc;
+      border-radius: 4px;
+      padding: 0.75rem;
+      background-color: #f9fafc;
+    }
+    .qc-summary-card--changed {
+      border-color: #4f46e5;
+      background-color: #eef2ff;
+    }
+    .qc-summary-label {
+      font-weight: 600;
+      display: block;
+      color: #555;
+    }
+    .qc-summary-value {
+      font-size: 1.5rem;
+      font-weight: 700;
+      display: block;
+      margin-top: 0.25rem;
+    }
+    .qc-summary-delta {
+      font-size: 0.85rem;
+      color: #555;
+    }
+    .qc-warning-list {
+      margin: 0.5rem 0 0;
+      padding-left: 1.25rem;
+    }
+    .qc-warning-ack-container {
+      margin-top: 0.75rem;
+      display: grid;
+      gap: 0.5rem;
+    }
+    .qc-warning-ack {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9rem;
+    }
+    .qc-preview-panel {
+      padding: 16px;
+    }
+    .qc-preview-panel .template-detail-container {
+      margin: 0;
+    }
+    .qc-preview-panel table {
+      font-size: 0.85rem;
+    }
     .qc-field-grid--compact {
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 0.5rem 0.75rem;
@@ -386,6 +441,12 @@
           No media preview is available for this record.
         </div>
       {% endif %}
+      {% if qc_preview %}
+      <div class="qc-preview-panel">
+        <h3 class="w3-margin-top w3-margin-bottom">Preview accession</h3>
+        {% include "cms/partials/accession_preview_panel.html" with accession=qc_preview.accession geologies=qc_preview.geologies accession_rows=qc_preview.accession_rows first_identifications=qc_preview.first_identifications identification_counts=qc_preview.identification_counts taxonomy=qc_preview.taxonomy references=qc_preview.references preview_mode=True %}
+      </div>
+      {% endif %}
     </aside>
 
     <form method="post" class="qc-form w3-card w3-white w3-padding" data-controller="qc-rows">
@@ -420,6 +481,8 @@
           <option value="{{ option }}"></option>
         {% endfor %}
       </datalist>
+
+      {% include "cms/qc/summary_step.html" %}
 
       {% block wizard_extra_fields %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- add a reusable qc.diff helper package and preview builder used by the expert wizard
- extend the expert wizard UI with a summary step, warning acknowledgements, and an accession preview panel
- block approvals when QC warnings are not acknowledged and log acknowledgements when recorded
- cover the diff helper and expert approval gating with unit tests

## Testing
- python app/manage.py test cms.tests

------
https://chatgpt.com/codex/tasks/task_e_68dd35222a348329ab415255f2140a6f