### PR TITLE
Add reference creation tools and update QC identification summary

### DIFF
--- a/app/cms/static/cms/js/controllers/qc_references_controller.js
+++ b/app/cms/static/cms/js/controllers/qc_references_controller.js
@@ -1,0 +1,166 @@
+(function (global, factory) {
+  if (typeof module === "object" && typeof module.exports === "object") {
+    module.exports = factory(require("@hotwired/stimulus"));
+  } else {
+    var controllerClass = factory(global.Stimulus || null);
+    if (controllerClass) {
+      global.QcReferencesController = controllerClass;
+      global.QCReferencesController = controllerClass;
+    }
+  }
+})(typeof window !== "undefined" ? window : this, function (Stimulus) {
+  if (!Stimulus || !Stimulus.Controller) {
+    return null;
+  }
+
+  var Controller = Stimulus.Controller;
+
+  function parseInteger(value) {
+    var number = parseInt(value, 10);
+    return isNaN(number) ? 0 : number;
+  }
+
+  function replacePrefixTokens(html, prefix, index) {
+    if (typeof html !== "string") {
+      return "";
+    }
+    var pattern = new RegExp(prefix + "-__prefix__", "g");
+    return html.replace(pattern, prefix + "-" + index);
+  }
+
+  var QcReferencesController = class extends Controller {
+    static get targets() {
+      return ["container", "template", "emptyMessage"];
+    }
+
+    connect() {
+      this.formElement = this.element.closest("form");
+      this.prefix = this.element.dataset.formsetPrefix || "reference";
+      this.totalFormsInput = this._findManagementInput("TOTAL_FORMS");
+      this.refreshEmptyState();
+    }
+
+    addReference(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      if (!this.hasTemplateTarget || !this.hasContainerTarget) {
+        return;
+      }
+      var index = this._nextIndex();
+      var newElement = this._createReferenceElement(index);
+      if (!newElement) {
+        return;
+      }
+      var orderValue = this._nextOrder();
+      this._setOrderValue(newElement, orderValue);
+      this._ensureRefId(newElement, index);
+      this.containerTarget.appendChild(newElement);
+      this._setTotalForms(index + 1);
+      this.refreshEmptyState();
+      this._focusFirstField(newElement);
+    }
+
+    refreshEmptyState() {
+      if (!this.hasEmptyMessageTarget) {
+        return;
+      }
+      var hasReferences =
+        this.hasContainerTarget &&
+        this.containerTarget.querySelector("[data-qc-reference]");
+      this.emptyMessageTarget.hidden = Boolean(hasReferences);
+    }
+
+    _findManagementInput(suffix) {
+      if (!this.formElement) {
+        return null;
+      }
+      return this.formElement.querySelector(
+        'input[name="' + this.prefix + "-" + suffix + '"]'
+      );
+    }
+
+    _nextIndex() {
+      if (!this.totalFormsInput) {
+        return this._countReferences();
+      }
+      return parseInteger(this.totalFormsInput.value);
+    }
+
+    _nextOrder() {
+      if (!this.hasContainerTarget) {
+        return this._nextIndex();
+      }
+      var maxOrder = -1;
+      this.containerTarget
+        .querySelectorAll('input[name$="-order"]')
+        .forEach(function (input) {
+          var value = parseInteger(input.value);
+          if (value > maxOrder) {
+            maxOrder = value;
+          }
+        });
+      return maxOrder + 1;
+    }
+
+    _createReferenceElement(index) {
+      var templateHtml = this.templateTarget.innerHTML;
+      if (!templateHtml) {
+        return null;
+      }
+      var markup = replacePrefixTokens(templateHtml, this.prefix, index);
+      var wrapper = document.createElement("div");
+      wrapper.innerHTML = markup.trim();
+      return wrapper.firstElementChild;
+    }
+
+    _setOrderValue(element, value) {
+      if (!element) {
+        return;
+      }
+      var orderInput = element.querySelector('input[name$="-order"]');
+      if (orderInput) {
+        orderInput.value = String(value);
+      }
+    }
+
+    _ensureRefId(element, index) {
+      if (!element) {
+        return;
+      }
+      var refInput = element.querySelector('input[name$="-ref_id"]');
+      if (!refInput) {
+        return;
+      }
+      var current = (refInput.value || "").trim();
+      if (!current) {
+        refInput.value = "new-ref-" + Date.now() + "-" + index;
+      }
+    }
+
+    _setTotalForms(value) {
+      if (this.totalFormsInput) {
+        this.totalFormsInput.value = String(value);
+      }
+    }
+
+    _countReferences() {
+      if (!this.hasContainerTarget) {
+        return 0;
+      }
+      return this.containerTarget.querySelectorAll("[data-qc-reference]").length;
+    }
+
+    _focusFirstField(element) {
+      if (!element) {
+        return;
+      }
+      var field = element.querySelector("input, textarea, select");
+      if (field && typeof field.focus === "function") {
+        field.focus();
+      }
+    }
+  };
+
+  return QcReferencesController;
+});

--- a/app/cms/static/cms/js/controllers/qc_rows_controller.js
+++ b/app/cms/static/cms/js/controllers/qc_rows_controller.js
@@ -1177,16 +1177,9 @@
       var type = chip.getAttribute('data-chip-type');
       var summary = '';
       if (type === 'ident') {
-        var taxonField = chip.querySelector('select[name$="-taxon"]');
-        summary = optionText(taxonField);
         var verbatim = chip.querySelector('textarea[name$="-verbatim_identification"], input[name$="-verbatim_identification"]');
-        if (!summary && verbatim && verbatim.value) {
-          summary = verbatim.value;
-        }
-        var qualifier = chip.querySelector('input[name$="-identification_qualifier"], select[name$="-identification_qualifier"]');
-        if (qualifier && qualifier.value) {
-          var qualifierText = optionText(qualifier);
-          summary = summary ? qualifierText + ' ' + summary : qualifierText;
+        if (verbatim && verbatim.value) {
+          summary = verbatim.value.trim();
         }
       } else {
         var elementField = chip.querySelector('select[name$="-element"]');

--- a/app/cms/static/cms/js/controllers/qc_rows_controller.js
+++ b/app/cms/static/cms/js/controllers/qc_rows_controller.js
@@ -270,6 +270,7 @@
         this.assignChipToRow(chip, row);
       }
       this.refreshChipSummary(chip);
+      this.bindChipSummaryEvents(chip);
       if (this.isChipMarkedForDeletion(chip)) {
         chip.dataset.chipRemoved = 'true';
         chip.hidden = true;
@@ -292,6 +293,42 @@
         removeButton.addEventListener('click', this.boundRequestChipRemoval);
         removeButton.setAttribute('data-qc-chip-remove-bound', 'true');
       }
+    }
+
+    bindChipSummaryEvents(chip) {
+      if (!chip) {
+        return;
+      }
+      var self = this;
+      var handler = function () {
+        self.refreshChipSummary(chip);
+      };
+      var type = chip.getAttribute('data-chip-type');
+      var selectors;
+      if (type === 'ident') {
+        selectors = [
+          'textarea[name$="-verbatim_identification"]',
+          'input[name$="-verbatim_identification"]',
+        ];
+      } else {
+        selectors = [
+          'select[name$="-element"]',
+          'textarea[name$="-verbatim_element"]',
+          'input[name$="-verbatim_element"]',
+          'input[name$="-portion"]',
+        ];
+      }
+      selectors.forEach(function (selector) {
+        var fields = chip.querySelectorAll(selector);
+        fields.forEach(function (field) {
+          if (!field || field.dataset.qcSummaryBound === 'true') {
+            return;
+          }
+          field.addEventListener('input', handler);
+          field.addEventListener('change', handler);
+          field.dataset.qcSummaryBound = 'true';
+        });
+      });
     }
 
     setupConflictCards() {

--- a/app/cms/templates/cms/qc/partials/reference_card.html
+++ b/app/cms/templates/cms/qc/partials/reference_card.html
@@ -1,0 +1,35 @@
+<div class="qc-card" data-qc-reference>
+  {% for hidden in ref_form.hidden_fields %}
+    {{ hidden }}
+  {% endfor %}
+  <div class="qc-field-grid">
+    <div class="qc-field qc-field--full">
+      <label class="qc-label" for="{{ ref_form.first_author.id_for_label }}">{{ ref_form.first_author.label }}:</label>
+      <div class="qc-control">
+        {{ ref_form.first_author }}
+        {{ ref_form.first_author.errors }}
+      </div>
+    </div>
+    <div class="qc-field qc-field--full">
+      <label class="qc-label" for="{{ ref_form.title.id_for_label }}">{{ ref_form.title.label }}:</label>
+      <div class="qc-control">
+        {{ ref_form.title }}
+        {{ ref_form.title.errors }}
+      </div>
+    </div>
+    <div class="qc-field">
+      <label class="qc-label" for="{{ ref_form.year.id_for_label }}">{{ ref_form.year.label }}:</label>
+      <div class="qc-control">
+        {{ ref_form.year }}
+        {{ ref_form.year.errors }}
+      </div>
+    </div>
+    <div class="qc-field">
+      <label class="qc-label" for="{{ ref_form.page.id_for_label }}">{{ ref_form.page.label }}:</label>
+      <div class="qc-control">
+        {{ ref_form.page }}
+        {{ ref_form.page.errors }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/cms/templates/cms/qc/wizard_base.html
+++ b/app/cms/templates/cms/qc/wizard_base.html
@@ -527,53 +527,35 @@
         </div>
       </section>
 
-      <section class="qc-section">
+      <section class="qc-section" data-controller="qc-references" data-formset-prefix="reference">
         <div class="qc-section-heading w3-border-bottom w3-padding-small">
           <h3>References</h3>
           <span class="qc-inline-note">Verify bibliographic entries from the card back.</span>
         </div>
+        <div class="w3-margin-bottom">
+          <button
+            type="button"
+            class="w3-button w3-tiny w3-blue w3-round"
+            data-action="click->qc-references#addReference"
+          >
+            Add reference
+          </button>
+        </div>
 
-        {% if reference_formset.forms %}
+        <div data-qc-references-target="container">
           {% for ref_form in reference_formset %}
-            <div class="qc-card">
-              {% for hidden in ref_form.hidden_fields %}
-                {{ hidden }}
-              {% endfor %}
-              <div class="qc-field-grid">
-                <div class="qc-field qc-field--full">
-                  <label class="qc-label" for="{{ ref_form.first_author.id_for_label }}">{{ ref_form.first_author.label }}:</label>
-                  <div class="qc-control">
-                    {{ ref_form.first_author }}
-                    {{ ref_form.first_author.errors }}
-                  </div>
-                </div>
-                <div class="qc-field qc-field--full">
-                  <label class="qc-label" for="{{ ref_form.title.id_for_label }}">{{ ref_form.title.label }}:</label>
-                  <div class="qc-control">
-                    {{ ref_form.title }}
-                    {{ ref_form.title.errors }}
-                  </div>
-                </div>
-                <div class="qc-field">
-                  <label class="qc-label" for="{{ ref_form.year.id_for_label }}">{{ ref_form.year.label }}:</label>
-                  <div class="qc-control">
-                    {{ ref_form.year }}
-                    {{ ref_form.year.errors }}
-                  </div>
-                </div>
-                <div class="qc-field">
-                  <label class="qc-label" for="{{ ref_form.page.id_for_label }}">{{ ref_form.page.label }}:</label>
-                  <div class="qc-control">
-                    {{ ref_form.page }}
-                    {{ ref_form.page.errors }}
-                  </div>
-                </div>
-              </div>
-            </div>
+            {% include "cms/qc/partials/reference_card.html" with ref_form=ref_form %}
           {% endfor %}
-        {% else %}
-          <p class="qc-inline-note">No references were interpreted for this accession.</p>
-        {% endif %}
+        </div>
+        <p
+          class="qc-inline-note"
+          data-qc-references-target="emptyMessage"{% if reference_formset.forms %} hidden{% endif %}
+        >
+          No references were interpreted for this accession.
+        </p>
+        <template data-qc-references-target="template">
+          {% include "cms/qc/partials/reference_card.html" with ref_form=reference_formset.empty_form %}
+        </template>
       </section>
 
       <section class="qc-section">
@@ -704,6 +686,7 @@
   {{ block.super }}
   <script src="https://unpkg.com/@hotwired/stimulus/dist/stimulus.umd.js"></script>
   <script src="{% static 'cms/js/controllers/qc_rows_controller.js' %}"></script>
+  <script src="{% static 'cms/js/controllers/qc_references_controller.js' %}"></script>
   <script src="{% static 'cms/js/media_intern_qc.js' %}"></script>
   <script>
     (function () {
@@ -728,6 +711,14 @@
       } else {
         console.error(
           'QcRowsController not found on window (UMD/global). If this file switches to ES modules, use an ES module setup.'
+        );
+      }
+
+      if (window.QcReferencesController) {
+        app.register('qc-references', window.QcReferencesController);
+      } else {
+        console.error(
+          'QcReferencesController not found on window (UMD/global). Ensure the controller script is included.'
         );
       }
     })();

--- a/app/cms/templates/cms/qc/wizard_base.html
+++ b/app/cms/templates/cms/qc/wizard_base.html
@@ -61,6 +61,13 @@
       gap: 0.75rem;
       padding: 0.25rem 0;
     }
+    .qc-chip[data-chip-type="ident"] .qc-field {
+      grid-template-columns: minmax(150px, max-content) minmax(0, 1fr);
+      align-items: flex-start;
+    }
+    .qc-chip[data-chip-type="ident"] .qc-label {
+      margin-bottom: 0;
+    }
     .qc-label {
       font-weight: 600;
       margin: 0;
@@ -417,10 +424,7 @@
         margin-bottom: 0.25rem;
       }
       .qc-chip[data-chip-type="ident"] .qc-field {
-        grid-template-columns: minmax(120px, 1fr) 1fr;
-      }
-      .qc-chip[data-chip-type="ident"] .qc-label {
-        margin-bottom: 0;
+        grid-template-columns: minmax(140px, max-content) minmax(0, 1fr);
       }
       .qc-row-actions {
         justify-content: flex-start;

--- a/app/cms/templates/cms/qc/wizard_base.html
+++ b/app/cms/templates/cms/qc/wizard_base.html
@@ -416,10 +416,10 @@
       .qc-label {
         margin-bottom: 0.25rem;
       }
-      .qc-chip .qc-field {
+      .qc-chip[data-chip-type="ident"] .qc-field {
         grid-template-columns: minmax(120px, 1fr) 1fr;
       }
-      .qc-chip .qc-label {
+      .qc-chip[data-chip-type="ident"] .qc-label {
         margin-bottom: 0;
       }
       .qc-row-actions {

--- a/app/cms/templates/cms/qc/wizard_base.html
+++ b/app/cms/templates/cms/qc/wizard_base.html
@@ -416,6 +416,12 @@
       .qc-label {
         margin-bottom: 0.25rem;
       }
+      .qc-chip .qc-field {
+        grid-template-columns: minmax(120px, 1fr) 1fr;
+      }
+      .qc-chip .qc-label {
+        margin-bottom: 0;
+      }
       .qc-row-actions {
         justify-content: flex-start;
       }

--- a/app/cms/tests.py
+++ b/app/cms/tests.py
@@ -3484,6 +3484,39 @@ class MediaInternQCWizardTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("Shelf 42", response.context["storage_suggestions"])
 
+    def test_can_add_reference_entry(self):
+        self.client.login(username="intern", password="pass")
+        url = self.get_url()
+        data = self.build_valid_post_data()
+        data.update(
+            {
+                "reference-TOTAL_FORMS": "3",
+                "reference-1-ref_id": "",
+                "reference-1-order": "1",
+                "reference-1-first_author": "New Author",
+                "reference-1-title": "New Insights",
+                "reference-1-year": "2020",
+                "reference-1-page": "10-12",
+                "reference-2-ref_id": "",
+                "reference-2-order": "2",
+                "reference-2-first_author": "  ",
+                "reference-2-title": "",
+                "reference-2-year": "",
+                "reference-2-page": "",
+            }
+        )
+
+        response = self.client.post(url, data, follow=True)
+        self.assertEqual(response.status_code, 200)
+
+        self.media.refresh_from_db()
+        references = self.media.ocr_data["accessions"][0]["references"]
+        self.assertEqual(len(references), 2)
+        self.assertEqual(
+            references[1]["reference_first_author"]["interpreted"], "New Author"
+        )
+        self.assertEqual(references[1]["page"]["interpreted"], "10-12")
+
     def test_handles_inserted_row_payload(self):
         self.client.login(username="intern", password="pass")
         url = self.get_url()


### PR DESCRIPTION
## Summary
- enable creating additional references during QC by introducing a Stimulus controller, reusable reference card partial, and an add-reference UI action
- relax reference QC form requirements, ignore blank submissions, and cover the workflow with a regression test
- update identification chip captions so they rely solely on the Taxon verbatim field

## Testing
- python manage.py test cms.tests

------
https://chatgpt.com/codex/tasks/task_e_68dd7cb20c6483298b2fedc363d21566