### PR TITLE
Restrict intern queue to OCR-complete media

### DIFF
--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -433,7 +433,11 @@ def dashboard(request):
         {
             "key": "pending_intern",
             "label": "Pending intern review",
-            "filters": {"qc_status": Media.QCStatus.PENDING_INTERN},
+            "filters": {
+                "qc_status": Media.QCStatus.PENDING_INTERN,
+                "ocr_status": Media.OCRStatus.COMPLETED,
+                "media_location__startswith": "uploads/ocr/",
+            },
             "action_url_name": "media_intern_qc",
             "cta_label": "Review",
             "empty_message": "No media awaiting intern review.",
@@ -588,7 +592,11 @@ class MediaQCQueueView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
 
 class MediaPendingInternQueueView(MediaQCQueueView):
-    filters = {"qc_status": Media.QCStatus.PENDING_INTERN}
+    filters = {
+        "qc_status": Media.QCStatus.PENDING_INTERN,
+        "ocr_status": Media.OCRStatus.COMPLETED,
+        "media_location__startswith": "uploads/ocr/",
+    }
     allowed_roles = {"intern", "expert"}
     queue_title = "Pending intern review"
     queue_action_url_name = "media_intern_qc"


### PR DESCRIPTION
## Summary
- require pending intern dashboard and queue views to only surface OCR-complete media living in the uploads/ocr/ directory
- update dashboard and notification tests to create OCR-ready pending intern fixtures and cover exclusion of incomplete media
- adjust scanning and expert QC wizard tests to reflect the new OCR-ready defaults

## Testing
- python app/manage.py test cms.tests


------
https://chatgpt.com/codex/tasks/task_e_68e3951671e88329baba854c2c058944