### PR TITLE
Ensure upload scan form resyncs files before submission

### DIFF
--- a/app/cms/templates/admin/upload_scan.html
+++ b/app/cms/templates/admin/upload_scan.html
@@ -164,6 +164,9 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   form.addEventListener('submit', () => {
+    if (supportsDataTransfer) {
+      syncInputFiles();
+    }
     const total = supportsDataTransfer
       ? filesQueue.length
       : (fileInput.files ? fileInput.files.length : 0);


### PR DESCRIPTION
## Summary
- resync the multi-file input with the queued files right before submitting the scan upload form
- prevent browsers from sending an empty payload when the queue is built through the DataTransfer API

## Testing
- not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4cb65e2d4832996d7b1c6dbb55eb5