### PR TITLE
Track OpenAI usage data in OCR pipeline

### DIFF
--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -19,6 +19,15 @@ from pathlib import Path
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
+# Per-model OpenAI pricing expressed as USD per token for prompt and completion
+# usage. The values default to the public rates as of May 2024 and can be
+# overridden via ``settings_local.py`` or environment variables if needed.
+OPENAI_PRICING = {
+    "gpt-4o": {"prompt": 0.000005, "completion": 0.000015},
+    "gpt-4o-mini": {"prompt": 0.00000015, "completion": 0.0000006},
+}
+
 try:
     with open(os.path.join(BASE_DIR, "config.json")) as config_file:
         config = json.load(config_file)


### PR DESCRIPTION
## Summary
- add an OpenAI pricing table to Django settings for prompt/completion token rates
- derive real usage + cost metadata from chat completions and persist it with OCR results
- update OCR-related tests to expect the new usage payload and reuse a helper when mocking responses

## Testing
- python app/manage.py test cms.tests --verbosity 2

------
https://chatgpt.com/codex/tasks/task_e_68e4dc5b815c8329af8de1a8f5bd5f6a