### PR TITLE
Handle OCR quota errors and add usage estimates

### DIFF
--- a/app/cms/templates/admin/base_site.html
+++ b/app/cms/templates/admin/base_site.html
@@ -11,6 +11,6 @@
 {% block nav-global %}
   <!-- Navigation shortcut to the scan upload form -->
   <a href="{% url 'admin-upload-scan' %}" class="button">Upload scans</a>
-  <a href="{% url 'admin-do-ocr' %}?loop=1" class="button">Do OCR</a>
+  <a href="{% url 'admin-do-ocr' %}" class="button">Do OCR</a>
   <a href="{% url 'admin-chatgpt-usage' %}" class="button">ChatGPT usage</a>
 {% endblock %}

--- a/app/cms/templates/admin/chatgpt_usage_report.html
+++ b/app/cms/templates/admin/chatgpt_usage_report.html
@@ -74,6 +74,9 @@
       <article class="summary-card">
         <h2>Remaining quota</h2>
         <p>${{ remaining_quota_usd|floatformat:2 }}</p>
+        {% if estimated_scans_remaining is not None %}
+          <p class="summary-subtext">~{{ estimated_scans_remaining|intcomma }} scans at avg ${{ avg_cost_per_scan|default_if_none:0|floatformat:4 }} each</p>
+        {% endif %}
       </article>
     {% endif %}
   </section>
@@ -213,6 +216,13 @@
     .summary-card p {
       font-size: 1.2rem;
       font-weight: 600;
+    }
+
+    .summary-card .summary-subtext {
+      font-size: 0.9rem;
+      font-weight: 400;
+      color: #555;
+      margin-top: 0.25rem;
     }
 
     .usage-visualizations {

--- a/app/cms/templates/admin/do_ocr_prompt.html
+++ b/app/cms/templates/admin/do_ocr_prompt.html
@@ -1,0 +1,74 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+  <h1>Process pending scans</h1>
+  <p>There are <strong>{{ pending_total }}</strong> scans awaiting OCR.</p>
+
+  <form method="post" class="ocr-limit-form">
+    {% csrf_token %}
+    <fieldset>
+      <legend>Select how many scans to process</legend>
+      {% if selection_error %}
+        <p class="errorlist"><strong>{{ selection_error }}</strong></p>
+      {% endif %}
+      <ul class="option-list">
+        <li>
+          <label>
+            <input type="radio" name="scan_limit" value="all"
+                   {% if not selected_choice or selected_choice == "all" %}checked{% endif %}
+                   {% if pending_total == 0 %}disabled{% endif %}>
+            Process all pending scans ({{ pending_total }})
+          </label>
+        </li>
+        {% for option in limit_options %}
+          <li>
+            <label>
+              <input type="radio" name="scan_limit" value="{{ option }}"
+                     {% if selected_choice == option|stringformat:"s" %}checked{% endif %}
+                     {% if pending_total == 0 %}disabled{% endif %}>
+              Process {{ option }} scans
+            </label>
+          </li>
+        {% endfor %}
+      </ul>
+      <div class="form-actions">
+        <button type="submit" class="default" {% if pending_total == 0 %}disabled{% endif %}>Start processing</button>
+        <a href="{% url 'admin:index' %}" class="button">Cancel</a>
+      </div>
+    </fieldset>
+  </form>
+
+  <style>
+    .ocr-limit-form fieldset {
+      border: 1px solid #ddd;
+      padding: 1.5rem;
+      background-color: #fff;
+      max-width: 480px;
+    }
+
+    .ocr-limit-form .option-list {
+      list-style: none;
+      margin: 1rem 0;
+      padding: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .ocr-limit-form label {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .ocr-limit-form .form-actions {
+      display: flex;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+    }
+
+    .ocr-limit-form .errorlist {
+      color: #a30000;
+      margin: 0 0 0.75rem 0;
+    }
+  </style>
+{% endblock %}


### PR DESCRIPTION
## Summary
- detect OpenAI insufficient quota responses during OCR, keep scans pending, and surface a user-facing error
- add an admin prompt to choose how many scans to process and stop looping when the selected limit is reached
- show estimated scans remaining based on budget in the ChatGPT usage report and update tests accordingly

## Testing
- python manage.py test cms.tests 【e88e4f†L1-L8】

------
https://chatgpt.com/codex/tasks/task_e_68e51c058c7c83299c95945c3143c2e0