### PR TITLE
Add merge framework scaffolding and permissions

### DIFF
--- a/app/cms/merge/__init__.py
+++ b/app/cms/merge/__init__.py
@@ -1,0 +1,6 @@
+"""Public interface for the CMS merge framework."""
+from .constants import MergeStrategy
+from .mixins import MergeMixin
+from .registry import MERGE_REGISTRY, register_merge_rules
+
+__all__ = ["MergeMixin", "MergeStrategy", "MERGE_REGISTRY", "register_merge_rules"]

--- a/app/cms/merge/constants.py
+++ b/app/cms/merge/constants.py
@@ -1,0 +1,36 @@
+"""Constants and enumerations used by the merge framework."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class MergeStrategy(str, Enum):
+    """Strategies that describe how conflicting values should be reconciled."""
+
+    LAST_WRITE = "last_write"
+    """Always prefer the value from the most recently saved record."""
+
+    PREFER_NON_NULL = "prefer_non_null"
+    """Choose the first non-empty value when merging two records."""
+
+    CONCAT_TEXT = "concat_text"
+    """Concatenate text values with a separator to preserve both inputs."""
+
+    WHITELIST = "whitelist"
+    """Limit merge candidates to an allow-listed field or relation set."""
+
+    CUSTOM = "custom"
+    """Use project specific logic registered in the merge registry."""
+
+    USER_PROMPT = "user_prompt"
+    """Defer to a human to resolve the field during the merge session."""
+
+
+#: Default strategy used when a field does not define explicit behaviour.
+DEFAULT_FIELD_STRATEGY: MergeStrategy = MergeStrategy.PREFER_NON_NULL
+
+#: Default strategy that can be used for relations when no override is defined.
+DEFAULT_RELATION_STRATEGY: MergeStrategy = MergeStrategy.LAST_WRITE
+
+#: Convenience tuple for widgets that need to display available strategies.
+MERGE_STRATEGY_CHOICES = tuple((strategy.value, strategy.name.title()) for strategy in MergeStrategy)

--- a/app/cms/merge/fuzzy.py
+++ b/app/cms/merge/fuzzy.py
@@ -1,0 +1,33 @@
+"""Helpers for fuzzy string matching used during merge candidate discovery."""
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+try:  # pragma: no cover - dependency injection is environment specific
+    from rapidfuzz import fuzz
+except ImportError:  # pragma: no cover
+    try:
+        from fuzzywuzzy import fuzz  # type: ignore[assignment]
+    except ImportError:  # pragma: no cover
+        fuzz = None  # type: ignore[assignment]
+
+
+def similarity_ratio(left: str, right: str) -> float:
+    """Return the token set similarity ratio between two strings."""
+
+    if not fuzz:
+        raise RuntimeError("Fuzzy matching dependencies are not installed.")
+    return float(fuzz.token_set_ratio(left or "", right or ""))
+
+
+def rank_candidates(source: str, candidates: Iterable[str]) -> Tuple[str, float]:
+    """Return the best matching candidate using the configured fuzzy scorer."""
+
+    best_value: float = -1
+    best_candidate: str = ""
+    for candidate in candidates:
+        score = similarity_ratio(source, candidate)
+        if score > best_value:
+            best_value = score
+            best_candidate = candidate
+    return best_candidate, best_value

--- a/app/cms/merge/mixins.py
+++ b/app/cms/merge/mixins.py
@@ -1,0 +1,71 @@
+"""Reusable mixins that provide merge behaviour to Django models."""
+from __future__ import annotations
+
+from typing import Any, ClassVar, Dict, Iterable, MutableMapping
+
+from django.db import models
+
+from .constants import DEFAULT_FIELD_STRATEGY, DEFAULT_RELATION_STRATEGY, MergeStrategy
+from .serializers import serialize_instance
+
+
+class MergeMixin(models.Model):
+    """Abstract model that exposes hooks required by the merge workflow."""
+
+    #: Mapping of field names to merge strategies. Sub-classes can override this
+    #: to fine tune default behaviour for individual fields.
+    merge_fields: ClassVar[MutableMapping[str, MergeStrategy | str]] = {}
+
+    #: Mapping of relation field names (FK/M2M) to merge strategies.
+    relation_strategies: ClassVar[MutableMapping[str, MergeStrategy | str]] = {}
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def get_merge_strategy_for_field(cls, field_name: str) -> MergeStrategy | str:
+        """Return the strategy that should be applied to a concrete field."""
+
+        return cls.merge_fields.get(field_name, DEFAULT_FIELD_STRATEGY)
+
+    @classmethod
+    def get_relation_strategy(cls, relation_name: str) -> MergeStrategy | str:
+        """Return the strategy to use for relations when merging records."""
+
+        return cls.relation_strategies.get(relation_name, DEFAULT_RELATION_STRATEGY)
+
+    def get_merge_display_fields(self) -> Iterable[str]:
+        """
+        Return a list of field names to display in merge previews.
+
+        By default the method returns the first five editable concrete fields
+        excluding the primary key. Projects can override this to surface the
+        most meaningful identifiers.
+        """
+
+        candidates: list[str] = []
+        for field in self._meta.concrete_fields:  # type: ignore[attr-defined]
+            if not getattr(field, "editable", False):
+                continue
+            if field.primary_key:
+                continue
+            candidates.append(field.name)
+            if len(candidates) >= 5:
+                break
+        return candidates
+
+    def snapshot_before_merge(self) -> Dict[str, Any]:
+        """Return a serialised snapshot of the record before merging."""
+
+        return serialize_instance(self)
+
+    def archive_source_instance(self, source_instance: "MergeMixin") -> None:
+        """
+        Hook that allows sub-classes to archive or deactivate the source record.
+
+        The default implementation is a stub to keep the mixin opt-in friendly;
+        projects can override when they want to soft-delete or otherwise record
+        the outcome of the merge.
+        """
+
+        return None

--- a/app/cms/merge/registry.py
+++ b/app/cms/merge/registry.py
@@ -1,0 +1,30 @@
+"""Simple registry utilities for storing merge specific rules."""
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, MutableMapping, Type
+
+from django.db import models
+
+from .constants import MergeStrategy
+
+MERGE_REGISTRY: MutableMapping[Type[models.Model], Dict[str, Any]] = {}
+
+
+def register_merge_rules(
+    model: Type[models.Model],
+    *,
+    fields: Mapping[str, MergeStrategy | str] | None = None,
+    relations: Mapping[str, MergeStrategy | str] | None = None,
+) -> None:
+    """Register custom merge rules for a model class."""
+
+    record = MERGE_REGISTRY.setdefault(model, {"fields": {}, "relations": {}})
+    if fields:
+        record["fields"].update(fields)
+    if relations:
+        record["relations"].update(relations)
+
+    if hasattr(model, "merge_fields") and isinstance(model.merge_fields, MutableMapping):
+        model.merge_fields.update(record["fields"])
+    if hasattr(model, "relation_strategies") and isinstance(model.relation_strategies, MutableMapping):
+        model.relation_strategies.update(record["relations"])

--- a/app/cms/merge/serializers.py
+++ b/app/cms/merge/serializers.py
@@ -1,0 +1,30 @@
+"""Utilities to capture and serialise the state of Django model instances."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping
+
+from django.forms.models import model_to_dict
+
+
+def serialize_instance(
+    instance,
+    *,
+    fields: Iterable[str] | None = None,
+    exclude: Iterable[str] | None = None,
+) -> Dict[str, Any]:
+    """Return a dictionary representing the model's current state."""
+
+    return model_to_dict(instance, fields=fields, exclude=exclude)
+
+
+def flatten_related(instance) -> Mapping[str, Any]:
+    """Return a mapping of related field names to their primary keys."""
+
+    related_state: Dict[str, Any] = {}
+    for field in instance._meta.related_objects:  # type: ignore[attr-defined]
+        accessor = getattr(instance, field.get_accessor_name())
+        if field.one_to_many or field.many_to_many:
+            related_state[field.name] = list(accessor.values_list("pk", flat=True))
+        else:
+            related_state[field.name] = getattr(accessor, "pk", None)
+    return related_state

--- a/app/cms/migrations/0062_merge_permissions.py
+++ b/app/cms/migrations/0062_merge_permissions.py
@@ -1,0 +1,37 @@
+# Generated manually for merge permissions
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("cms", "0061_llmusagerecord_processing_seconds_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="fieldslip",
+            options={
+                "ordering": ["field_number"],
+                "verbose_name": "Field Slip",
+                "verbose_name_plural": "Field Slips",
+                "permissions": [("can_merge", "Can merge field slip records")],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="storage",
+            options={
+                "verbose_name": "Storage",
+                "verbose_name_plural": "Storages",
+                "permissions": [("can_merge", "Can merge storage records")],
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="reference",
+            options={
+                "verbose_name": "Reference",
+                "verbose_name_plural": "References",
+                "permissions": [("can_merge", "Can merge reference records")],
+            },
+        ),
+    ]

--- a/app/cms/models.py
+++ b/app/cms/models.py
@@ -18,6 +18,7 @@ import string # For generating specimen number
 import uuid
 User = get_user_model()
 
+from .merge import MergeMixin, MergeStrategy
 from .notifications import notify_media_qc_transition
 
 
@@ -462,7 +463,12 @@ class Comment(BaseModel):
 
 
 # FieldSlip Model
-class FieldSlip(BaseModel):
+class FieldSlip(MergeMixin, BaseModel):
+    merge_fields = {
+        "field_number": MergeStrategy.PREFER_NON_NULL,
+        "verbatim_taxon": MergeStrategy.PREFER_NON_NULL,
+        "verbatim_element": MergeStrategy.PREFER_NON_NULL,
+    }
     field_number = models.CharField(max_length=100, null=False, blank=False, help_text="Field number assigned to the specimen.")
     discoverer = models.CharField(max_length=255, null=True, blank=True, help_text="Person who discovered the specimen.")
     collector = models.CharField(max_length=255, null=True, blank=True, help_text="Person who collected the specimen.")
@@ -491,9 +497,13 @@ class FieldSlip(BaseModel):
         ordering = ["field_number"]
         verbose_name = "Field Slip"
         verbose_name_plural = "Field Slips"
+        permissions = [("can_merge", "Can merge field slip records")]
 
 # Storage Model
-class Storage(BaseModel):
+class Storage(MergeMixin, BaseModel):
+    merge_fields = {
+        "area": MergeStrategy.PREFER_NON_NULL,
+    }
     area = models.CharField(
         max_length=255,
         blank=False,
@@ -515,13 +525,18 @@ class Storage(BaseModel):
     class Meta:
         verbose_name = "Storage"
         verbose_name_plural = "Storages"
+        permissions = [("can_merge", "Can merge storage records")]
 
     def __str__(self):
         return self.area
 
 
 # Reference Model
-class Reference(BaseModel):
+class Reference(MergeMixin, BaseModel):
+    merge_fields = {
+        "title": MergeStrategy.PREFER_NON_NULL,
+        "citation": MergeStrategy.CONCAT_TEXT,
+    }
     title = models.CharField(
         max_length=255,
         blank=False,
@@ -583,6 +598,7 @@ class Reference(BaseModel):
     class Meta:
         verbose_name = "Reference"
         verbose_name_plural = "References"
+        permissions = [("can_merge", "Can merge reference records")]
 
     def __str__(self):
         return self.citation

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -34,3 +34,6 @@ django-userforeignkey>=0.5.0
 django-filter>=23.1
 openai>=1.40.0
 python-dotenv>=1.0.1
+# Fuzzy matching libraries used for merge candidate discovery
+python-Levenshtein>=0.25.0
+rapidfuzz>=3.4.0


### PR DESCRIPTION
## Summary
- scaffold a reusable merge framework with strategies, mixin hooks, registry helpers, and fuzzy-matching utilities
- update FieldSlip, Storage, and Reference to opt into the merge mixin and declare merge permissions
- record the new permissions in migrations and add Levenshtein-powered dependencies for candidate discovery

## Testing
- python app/manage.py makemigrations --check

------
https://chatgpt.com/codex/tasks/task_e_68e525cd5a14832988be8e3a9d4ec978