### PR TITLE
Add admin merge candidate search API and UI

### DIFF
--- a/app/cms/merge/fuzzy.py
+++ b/app/cms/merge/fuzzy.py
@@ -1,7 +1,10 @@
 """Helpers for fuzzy string matching used during merge candidate discovery."""
 from __future__ import annotations
 
-from typing import Iterable, Tuple
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+from django.db import models
 
 try:  # pragma: no cover - dependency injection is environment specific
     from rapidfuzz import fuzz
@@ -31,3 +34,83 @@ def rank_candidates(source: str, candidates: Iterable[str]) -> Tuple[str, float]
             best_value = score
             best_candidate = candidate
     return best_candidate, best_value
+
+
+@dataclass(frozen=True)
+class CandidateMatch:
+    """Representation of a single merge candidate score."""
+
+    instance: models.Model
+    score: float
+    combined_text: str
+
+
+def _yield_candidate_text(instance: models.Model, fields: Sequence[str]) -> str:
+    """Return a normalised string representation for ``instance`` fields."""
+
+    parts: List[str] = []
+    for field_name in fields:
+        value = getattr(instance, field_name, "")
+        if value in (None, ""):
+            continue
+        parts.append(str(value))
+    return " ".join(parts)
+
+
+def score_candidates(
+    model: type[models.Model],
+    query: str,
+    *,
+    fields: Sequence[str],
+    threshold: float = 0,
+    queryset: models.QuerySet | None = None,
+) -> List[CandidateMatch]:
+    """Return an ordered list of candidate matches for ``query``.
+
+    Parameters
+    ----------
+    model:
+        Django model class that should be evaluated.
+    query:
+        Search phrase supplied by the admin user.
+    fields:
+        Iterable of field names that should be concatenated to build the text
+        corpus for each record.
+    threshold:
+        Minimum fuzzy ratio (0-100) a candidate must score to be included in
+        the result set. The default of ``0`` effectively disables thresholding.
+    queryset:
+        Optional queryset limiting the records evaluated. When omitted the
+        model's default manager will be used.
+
+    Returns
+    -------
+    list[CandidateMatch]
+        Ordered list of matches sorted by score in descending order.
+    """
+
+    if not query:
+        return []
+
+    if queryset is None:
+        queryset = model._default_manager.all()
+
+    cleaned_fields: List[str] = [field for field in fields if field]
+    if not cleaned_fields:
+        return []
+
+    matches: List[CandidateMatch] = []
+    for instance in queryset.iterator():
+        combined_text = _yield_candidate_text(instance, cleaned_fields)
+        if not combined_text:
+            continue
+        score = similarity_ratio(query, combined_text)
+        if score < threshold:
+            continue
+        matches.append(CandidateMatch(instance=instance, score=score, combined_text=combined_text))
+
+    matches.sort(key=lambda item: item.score, reverse=True)
+    return matches
+
+
+__all__ = ["similarity_ratio", "rank_candidates", "score_candidates", "CandidateMatch"]

--- a/app/cms/static/js/merge.js
+++ b/app/cms/static/js/merge.js
@@ -1,0 +1,307 @@
+(function () {
+  const root = document.querySelector('[data-merge-root]');
+  if (!root) {
+    return;
+  }
+
+  const searchForm = root.querySelector('[data-merge-search-form]');
+  const resultsContainer = root.querySelector('[data-merge-results]');
+  const statusContainer = root.querySelector('[data-merge-status]');
+  const errorEl = root.querySelector('[data-merge-error]');
+  const selectionContainer = root.querySelector('[data-merge-selection]');
+  const selectionInputs = {
+    source: root.querySelector('[data-merge-field="source"]'),
+    target: root.querySelector('[data-merge-field="target"]')
+  };
+  const selectionDisplays = {
+    source: root.querySelector('[data-merge-display="source"]'),
+    target: root.querySelector('[data-merge-display="target"]')
+  };
+  const clearButtons = root.querySelectorAll('[data-merge-clear]');
+  const resetButton = root.querySelector('[data-merge-reset]');
+  const resultTemplate = document.getElementById('merge-result-template');
+  const compareTemplate = document.getElementById('merge-compare-template');
+
+  let compareElement = null;
+
+  const setStatus = (message, tone) => {
+    if (!statusContainer) {
+      return;
+    }
+    if (!message) {
+      statusContainer.innerHTML = '';
+      statusContainer.setAttribute('hidden', 'hidden');
+      return;
+    }
+
+    statusContainer.removeAttribute('hidden');
+    statusContainer.className = 'w3-container';
+    let toneClass = 'w3-pale-blue w3-border-blue';
+    if (tone === 'error') {
+      toneClass = 'w3-pale-red w3-border-red';
+    } else if (tone === 'info') {
+      toneClass = 'w3-pale-yellow w3-border-amber';
+    } else if (tone === 'success') {
+      toneClass = 'w3-pale-green w3-border-green';
+    }
+    statusContainer.classList.add('w3-panel', 'w3-border', toneClass);
+    statusContainer.textContent = message;
+  };
+
+  const clearError = () => {
+    if (!errorEl) {
+      return;
+    }
+    errorEl.textContent = '';
+    errorEl.setAttribute('hidden', 'hidden');
+  };
+
+  const showError = (message) => {
+    if (!errorEl) {
+      setStatus(message, 'error');
+      return;
+    }
+    errorEl.textContent = message;
+    errorEl.removeAttribute('hidden');
+  };
+
+  const ensureCompareElement = () => {
+    if (!compareTemplate) {
+      return null;
+    }
+    if (compareElement && compareElement.isConnected) {
+      return compareElement;
+    }
+    const fragment = compareTemplate.content.cloneNode(true);
+    compareElement = fragment.querySelector('[data-merge-compare]');
+    if (!compareElement) {
+      return null;
+    }
+    if (selectionContainer && selectionContainer.parentNode) {
+      selectionContainer.parentNode.insertBefore(fragment, selectionContainer.nextSibling);
+    } else {
+      root.appendChild(fragment);
+    }
+    return compareElement;
+  };
+
+  const renderComparison = () => {
+    const sourcePreview = selectionInputs.source ? selectionInputs.source.dataset.preview : '';
+    const targetPreview = selectionInputs.target ? selectionInputs.target.dataset.preview : '';
+
+    if (!sourcePreview && !targetPreview) {
+      if (compareElement && compareElement.parentNode) {
+        compareElement.parentNode.removeChild(compareElement);
+      }
+      compareElement = null;
+      return;
+    }
+
+    const element = ensureCompareElement();
+    if (!element) {
+      return;
+    }
+
+    const sourceList = element.querySelector('[data-merge-compare-source]');
+    const targetList = element.querySelector('[data-merge-compare-target]');
+
+    const populateList = (node, previewJson) => {
+      if (!node) {
+        return;
+      }
+      node.innerHTML = '';
+      if (!previewJson) {
+        const emptyItem = document.createElement('li');
+        emptyItem.className = 'w3-text-grey';
+        emptyItem.textContent = 'No data available';
+        node.appendChild(emptyItem);
+        return;
+      }
+      let preview;
+      try {
+        preview = JSON.parse(previewJson);
+      } catch (error) {
+        const errorItem = document.createElement('li');
+        errorItem.className = 'w3-text-red';
+        errorItem.textContent = 'Unable to parse preview details.';
+        node.appendChild(errorItem);
+        return;
+      }
+      preview.forEach((row) => {
+        const item = document.createElement('li');
+        item.textContent = `${row.field}: ${row.value}`;
+        node.appendChild(item);
+      });
+    };
+
+    populateList(sourceList, sourcePreview);
+    populateList(targetList, targetPreview);
+  };
+
+  const clearSelections = (role) => {
+    const roles = role ? [role] : ['source', 'target'];
+    roles.forEach((currentRole) => {
+      const input = selectionInputs[currentRole];
+      const display = selectionDisplays[currentRole];
+      if (input) {
+        input.value = '';
+        delete input.dataset.preview;
+        delete input.dataset.label;
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      if (display) {
+        display.textContent = '';
+      }
+    });
+    renderComparison();
+  };
+
+  const renderResult = (result) => {
+    if (!resultTemplate) {
+      return;
+    }
+    const fragment = resultTemplate.content.cloneNode(true);
+    const container = fragment.querySelector('[data-merge-result]');
+    if (!container) {
+      return;
+    }
+
+    const labelNode = container.querySelector('[data-merge-label]');
+    const scoreNode = container.querySelector('[data-merge-score]');
+    const idNode = container.querySelector('[data-merge-object-id]');
+    const previewList = container.querySelector('[data-merge-preview]');
+
+    const candidate = result.candidate || {};
+    const preview = Array.isArray(result.preview) ? result.preview : [];
+
+    if (labelNode) {
+      labelNode.textContent = candidate.label || `Record ${candidate.pk ?? ''}`;
+    }
+    if (scoreNode) {
+      scoreNode.textContent = `${Math.round((result.score || 0) * 10) / 10}`;
+    }
+    if (idNode) {
+      idNode.textContent = candidate.pk ?? '';
+    }
+    if (previewList) {
+      previewList.innerHTML = '';
+      if (preview.length === 0) {
+        const emptyItem = document.createElement('li');
+        emptyItem.className = 'w3-text-grey';
+        emptyItem.textContent = 'No preview fields configured.';
+        previewList.appendChild(emptyItem);
+      } else {
+        preview.forEach((row) => {
+          const item = document.createElement('li');
+          item.textContent = `${row.field}: ${row.value}`;
+          previewList.appendChild(item);
+        });
+      }
+    }
+
+    container.querySelectorAll('[data-merge-select]').forEach((button) => {
+      button.addEventListener('click', () => {
+        const role = button.dataset.mergeSelect;
+        const input = selectionInputs[role];
+        const display = selectionDisplays[role];
+        if (!input) {
+          return;
+        }
+        input.value = candidate.pk ?? '';
+        input.dataset.preview = JSON.stringify(preview);
+        input.dataset.label = candidate.label || '';
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        if (display) {
+          const scoreLabel = result.score !== undefined ? ` (score ${Math.round(result.score)})` : '';
+          display.textContent = `${candidate.pk ?? ''} – ${candidate.label || ''}${scoreLabel}`;
+        }
+        renderComparison();
+      });
+    });
+
+    resultsContainer.appendChild(fragment);
+  };
+
+  const renderResults = (payload) => {
+    resultsContainer.innerHTML = '';
+    if (!payload || !Array.isArray(payload.results) || payload.results.length === 0) {
+      setStatus('No candidates found for the supplied search.', 'info');
+      return;
+    }
+    setStatus('Select a candidate to populate the merge form.', 'success');
+    payload.results.forEach(renderResult);
+  };
+
+  const buildQueryParams = (form) => {
+    const formData = new FormData(form);
+    const params = new URLSearchParams();
+    formData.forEach((value, key) => {
+      if (value === null || value === undefined || value === '') {
+        return;
+      }
+      params.append(key, value);
+    });
+    return params;
+  };
+
+  const fetchResults = async () => {
+    if (!searchForm) {
+      return;
+    }
+    clearError();
+    setStatus('Searching for candidates…', 'info');
+    const url = searchForm.dataset.searchUrl;
+    if (!url) {
+      showError('Search endpoint is not configured.');
+      return;
+    }
+    const params = buildQueryParams(searchForm);
+    try {
+      const response = await fetch(`${url}?${params.toString()}`, {
+        headers: { Accept: 'application/json' },
+        credentials: 'same-origin'
+      });
+      if (!response.ok) {
+        let message = `Request failed with status ${response.status}`;
+        try {
+          const errorData = await response.json();
+          if (errorData && errorData.detail) {
+            message = errorData.detail;
+          }
+        } catch (error) {
+          // ignore JSON parse errors and surface default message
+        }
+        throw new Error(message);
+      }
+      const payload = await response.json();
+      renderResults(payload);
+    } catch (error) {
+      showError(error.message || 'Unable to fetch merge candidates.');
+      resultsContainer.innerHTML = '';
+      setStatus(null);
+    }
+  };
+
+  if (searchForm) {
+    searchForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      fetchResults();
+    });
+  }
+
+  clearButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const role = button.dataset.mergeClear;
+      clearSelections(role);
+    });
+  });
+
+  if (resetButton) {
+    resetButton.addEventListener('click', () => {
+      clearSelections();
+      resultsContainer.innerHTML = '';
+      setStatus(null);
+      clearError();
+    });
+  }
+})();

--- a/app/cms/templates/admin/cms/merge/candidate_list.html
+++ b/app/cms/templates/admin/cms/merge/candidate_list.html
@@ -1,0 +1,116 @@
+{% extends "admin/base_site.html" %}
+{% load static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  <script src="{% static 'js/merge.js' %}" defer></script>
+{% endblock %}
+
+{% block content %}
+<div class="w3-container w3-margin-top" data-merge-root>
+  <div class="w3-card w3-padding">
+    <h2 class="w3-margin-top">Merge candidate search</h2>
+    <p class="w3-small w3-text-grey">
+      Use the form below to search for potential duplicates. The search uses fuzzy matching on the
+      selected fields and returns the closest matches first.
+    </p>
+    {% if not merge_models %}
+      <div class="w3-panel w3-pale-red w3-border w3-border-red">
+        <p class="w3-margin">No models are currently registered for merging. Register models in
+          <code>cms.merge.registry</code> to enable the interface.</p>
+      </div>
+    {% else %}
+      <form class="w3-row-padding" data-merge-search-form data-search-url="{{ search_url }}">
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_model">Model</label>
+          <select class="w3-select" name="model_label" id="id_merge_model" required>
+            {% for model in merge_models %}
+              <option value="{{ model.label }}">{{ model.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_query">Search term</label>
+          <input class="w3-input w3-border" type="text" id="id_merge_query" name="query" placeholder="e.g. Specimen number" required />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_threshold">Threshold</label>
+          <input class="w3-input w3-border" type="number" id="id_merge_threshold" name="threshold" min="0" max="100" step="1" value="{{ default_threshold }}" />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_fields">Fields (optional)</label>
+          <input class="w3-input w3-border" type="text" id="id_merge_fields" name="fields" placeholder="Comma separated field names" />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_date_field">Date field</label>
+          <input class="w3-input w3-border" type="text" id="id_merge_date_field" name="date_field" placeholder="created_at" />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_date_after">From date</label>
+          <input class="w3-input w3-border" type="date" id="id_merge_date_after" name="date_after" />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_date_before">To date</label>
+          <input class="w3-input w3-border" type="date" id="id_merge_date_before" name="date_before" />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_page_size">Page size</label>
+          <input class="w3-input w3-border" type="number" id="id_merge_page_size" name="page_size" min="1" max="200" value="25" />
+        </div>
+        <div class="w3-third w3-margin-bottom">
+          <label class="w3-text-grey" for="id_merge_filters">Filters (JSON)</label>
+          <input class="w3-input w3-border" type="text" id="id_merge_filters" name="filters" placeholder='{"collection": 1}' />
+        </div>
+        <div class="w3-col w3-margin-bottom">
+          <button class="w3-button w3-blue w3-margin-right" type="submit">Search</button>
+          <button class="w3-button w3-light-grey" type="reset" data-merge-reset>Reset</button>
+        </div>
+        <p class="w3-col w3-text-red w3-small" data-merge-error hidden></p>
+      </form>
+    {% endif %}
+  </div>
+
+  <div class="w3-row-padding w3-margin-top" data-merge-selection>
+    <div class="w3-half w3-margin-bottom">
+      <div class="w3-card w3-padding">
+        <h3 class="w3-margin-top">Source record</h3>
+        <input class="w3-input w3-border w3-margin-bottom" type="text" readonly name="source_id" data-merge-field="source" placeholder="No record selected" />
+        <p class="w3-small w3-text-grey" data-merge-display="source"></p>
+        <button class="w3-button w3-small w3-light-grey" type="button" data-merge-clear="source">Clear source</button>
+      </div>
+    </div>
+    <div class="w3-half w3-margin-bottom">
+      <div class="w3-card w3-padding">
+        <h3 class="w3-margin-top">Target record</h3>
+        <input class="w3-input w3-border w3-margin-bottom" type="text" readonly name="target_id" data-merge-field="target" placeholder="No record selected" />
+        <p class="w3-small w3-text-grey" data-merge-display="target"></p>
+        <button class="w3-button w3-small w3-light-grey" type="button" data-merge-clear="target">Clear target</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="w3-container" data-merge-status hidden></div>
+  <div class="w3-container" data-merge-results></div>
+</div>
+
+<template id="merge-result-template">
+  <div class="w3-card w3-margin-bottom w3-padding" data-merge-result>
+    <div class="w3-row">
+      <div class="w3-col m8">
+        <h4 class="w3-margin-top" data-merge-label></h4>
+        <p class="w3-small w3-text-grey">ID: <span data-merge-object-id></span></p>
+      </div>
+      <div class="w3-col m4 w3-right-align">
+        <span class="w3-tag w3-round w3-blue w3-large" data-merge-score></span>
+      </div>
+    </div>
+    <ul class="w3-ul w3-small" data-merge-preview></ul>
+    <div class="w3-bar w3-margin-top">
+      <button class="w3-button w3-green w3-margin-right" type="button" data-merge-select="source">Use as source</button>
+      <button class="w3-button w3-indigo" type="button" data-merge-select="target">Use as target</button>
+    </div>
+  </div>
+</template>
+
+{% include "admin/cms/merge/compare.html" %}
+{% endblock %}

--- a/app/cms/templates/admin/cms/merge/compare.html
+++ b/app/cms/templates/admin/cms/merge/compare.html
@@ -1,0 +1,19 @@
+{% comment %}
+  Template fragment used by merge.js to render a side-by-side comparison of two
+  selected records.
+{% endcomment %}
+<template id="merge-compare-template">
+  <div class="w3-card w3-margin-top w3-padding" data-merge-compare>
+    <h3 class="w3-margin-top">Compare selections</h3>
+    <div class="w3-row-padding">
+      <div class="w3-half">
+        <h4 class="w3-margin-top">Source</h4>
+        <ul class="w3-ul w3-small" data-merge-compare-source></ul>
+      </div>
+      <div class="w3-half">
+        <h4 class="w3-margin-top">Target</h4>
+        <ul class="w3-ul w3-small" data-merge-compare-target></ul>
+      </div>
+    </div>
+  </div>
+</template>

--- a/app/cms/urls.py
+++ b/app/cms/urls.py
@@ -1,6 +1,7 @@
 from django.urls import include, path
 from django.conf.urls.static import static
 from django.conf import settings
+from django.contrib.admin.views.decorators import staff_member_required as staff_login_required
 from django_filters.views import FilterView
 from cms.models import Accession
 from cms.views import (
@@ -70,6 +71,8 @@ from cms.views import (
     StorageDetailView,
     StorageCreateView,
     StorageUpdateView,
+    MergeCandidateAdminView,
+    MergeCandidateAPIView,
 )
 from .views import PreparationMediaUploadView
 from .views import FieldSlipAutocomplete, ReferenceAutocomplete
@@ -168,6 +171,11 @@ urlpatterns += [
 
 urlpatterns += [
     path("autocomplete/fieldslip/", FieldSlipAutocomplete.as_view(), name="fieldslip-autocomplete"),
+]
+
+urlpatterns += [
+    path("merge/", staff_login_required(MergeCandidateAdminView.as_view()), name="merge_candidates"),
+    path("merge/search/", staff_login_required(MergeCandidateAPIView.as_view()), name="merge_candidate_search"),
 ]
 
 urlpatterns += [

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -9,7 +9,8 @@ from typing import Any
 from urllib.parse import urlencode
 from dal import autocomplete
 from django import forms
-from django.db import transaction
+from django.apps import apps
+from django.db import models, transaction
 from django.db.models import Value, CharField, Count, Q, Max, Prefetch, OuterRef, Subquery, Sum
 from django.db.models.functions import Concat, Greatest, TruncDate, TruncWeek
 from django.http import JsonResponse
@@ -32,22 +33,23 @@ from .filters import (
 
 from django.views.generic import DetailView
 from django.core.files.storage import FileSystemStorage
-from django.core.paginator import Paginator
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.conf import settings
 
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.core.exceptions import ValidationError
+from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.forms import BaseFormSet, formset_factory, modelformset_factory
 from django.forms.widgets import Media as FormsMedia
 from django.http import HttpResponse, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, render, redirect
 from django.urls import reverse_lazy, reverse
 from django.utils import timezone
+from django.utils.dateparse import parse_date, parse_datetime
 from django.utils.timezone import now
-from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView, FormView
+from django.views.generic import ListView, DetailView, CreateView, UpdateView, DeleteView, FormView, TemplateView
 from django.core.serializers.json import DjangoJSONEncoder
 
 from cms.forms import (AccessionBatchForm, AccessionCommentForm,
@@ -95,6 +97,8 @@ from cms.models import (
     LLMUsageRecord,
 )
 
+from cms.merge import MERGE_REGISTRY, MergeMixin
+from cms.merge.fuzzy import score_candidates
 from cms.resources import FieldSlipResource
 from .utils import build_history_entries
 from cms.utils import generate_accessions_from_series
@@ -148,6 +152,281 @@ class ReferenceAutocomplete(LoginRequiredMixin, View):
         ]
 
         return JsonResponse({"results": results, "more": has_more})
+
+
+class MergeCandidateAdminView(LoginRequiredMixin, TemplateView):
+    """Render the administrative interface for locating merge candidates."""
+
+    template_name = "admin/cms/merge/candidate_list.html"
+    raise_exception = True
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_staff:
+            return HttpResponseForbidden("Staff access required.")
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["merge_models"] = self._get_merge_models()
+        context["search_url"] = reverse("merge_candidate_search")
+        context["default_threshold"] = 75
+        return context
+
+    def _get_merge_models(self) -> list[dict[str, str]]:
+        """Return a sorted list of merge-enabled models for the UI selector."""
+
+        options: list[dict[str, str]] = []
+        for model in MERGE_REGISTRY.keys():
+            meta = model._meta
+            label = f"{meta.app_label}.{meta.model_name}"
+            verbose_name = str(getattr(meta, "verbose_name_plural", meta.verbose_name)).title()
+            options.append({"label": label, "name": verbose_name})
+        options.sort(key=lambda item: item["name"])
+        return options
+
+
+class MergeCandidateAPIView(View):
+    """Expose fuzzy merge candidates for staff via a JSON API."""
+
+    http_method_names = ["get"]
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated or not request.user.is_staff:
+            return JsonResponse({"detail": "Forbidden"}, status=403)
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        try:
+            model = self._get_model_from_label(request.GET.get("model_label", ""))
+        except ValueError as exc:
+            return JsonResponse({"detail": str(exc)}, status=400)
+
+        query = (request.GET.get("query") or "").strip()
+        if not query:
+            return JsonResponse({"detail": "The `query` parameter is required."}, status=400)
+
+        threshold = self._parse_threshold(request.GET.get("threshold"))
+        if threshold is None:
+            return JsonResponse({"detail": "The `threshold` parameter must be numeric."}, status=400)
+
+        try:
+            fields = self._extract_fields(request, model)
+        except ValueError as exc:
+            return JsonResponse({"detail": str(exc)}, status=400)
+
+        if not fields:
+            return JsonResponse({"detail": "No fields available for scoring."}, status=400)
+
+        try:
+            queryset = self._build_queryset(request, model)
+        except ValueError as exc:
+            return JsonResponse({"detail": str(exc)}, status=400)
+
+        try:
+            matches = score_candidates(model, query, fields=fields, threshold=threshold, queryset=queryset)
+        except RuntimeError as exc:
+            return JsonResponse({"detail": str(exc)}, status=503)
+
+        page_size, paginator, page_obj = self._paginate(request, matches)
+
+        if paginator is None or page_obj is None:
+            payload = {
+                "model": f"{model._meta.app_label}.{model._meta.model_name}",
+                "query": query,
+                "threshold": threshold,
+                "page": 1,
+                "page_size": page_size,
+                "total_results": 0,
+                "num_pages": 0,
+                "preview_fields": fields,
+                "results": [],
+            }
+            return JsonResponse(payload)
+
+        payload = {
+            "model": f"{model._meta.app_label}.{model._meta.model_name}",
+            "query": query,
+            "threshold": threshold,
+            "page": page_obj.number,
+            "page_size": paginator.per_page,
+            "total_results": paginator.count,
+            "num_pages": paginator.num_pages,
+            "preview_fields": fields,
+            "results": [self._serialise_match(match, fields) for match in page_obj.object_list],
+        }
+        return JsonResponse(payload)
+
+    def _get_model_from_label(self, label: str):
+        if not label:
+            raise ValueError("The `model_label` parameter is required.")
+        if "." not in label:
+            raise ValueError("`model_label` must use the format 'app_label.ModelName'.")
+        app_label, model_name = label.split(".", 1)
+        try:
+            model = apps.get_model(app_label, model_name)
+        except LookupError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(str(exc)) from exc
+        if model is None:
+            raise ValueError(f"Unknown model '{label}'.")
+        if model not in MERGE_REGISTRY:
+            raise ValueError(f"Model '{label}' is not registered for merging.")
+        if not issubclass(model, MergeMixin):
+            raise ValueError(f"Model '{label}' must inherit from MergeMixin.")
+        return model
+
+    def _parse_threshold(self, raw_value: str | None) -> float | None:
+        if raw_value in (None, ""):
+            return 75.0
+        try:
+            value = float(raw_value)
+        except (TypeError, ValueError):
+            return None
+        return max(0.0, min(value, 100.0))
+
+    def _extract_fields(self, request, model) -> list[str]:
+        explicit_fields: list[str] = []
+        raw_multi = request.GET.getlist("fields")
+        for value in raw_multi:
+            for item in value.split(","):
+                candidate = item.strip()
+                if candidate:
+                    explicit_fields.append(candidate)
+        if not explicit_fields and request.GET.get("fields"):
+            for item in request.GET["fields"].split(","):
+                candidate = item.strip()
+                if candidate:
+                    explicit_fields.append(candidate)
+
+        if explicit_fields:
+            return explicit_fields
+
+        instance = None
+        try:
+            instance = model()
+        except TypeError:
+            instance = None
+
+        if isinstance(instance, MergeMixin):
+            inferred = list(instance.get_merge_display_fields())
+        else:
+            inferred = []
+
+        if not inferred:
+            inferred = []
+            for field in model._meta.concrete_fields:
+                if not getattr(field, "editable", False) or field.primary_key:
+                    continue
+                inferred.append(field.name)
+                if len(inferred) >= 5:
+                    break
+
+        return inferred
+
+    def _build_queryset(self, request, model):
+        queryset = model._default_manager.all()
+        filters_payload = request.GET.get("filters")
+        filter_kwargs: dict[str, Any] = {}
+        if filters_payload:
+            try:
+                decoded = json.loads(filters_payload)
+            except json.JSONDecodeError as exc:
+                raise ValueError("`filters` must contain valid JSON.") from exc
+            if not isinstance(decoded, dict):
+                raise ValueError("`filters` must be a JSON object.")
+            filter_kwargs.update(decoded)
+
+        date_field = request.GET.get("date_field")
+        if date_field:
+            try:
+                field = model._meta.get_field(date_field)
+            except FieldDoesNotExist as exc:
+                raise ValueError(f"Unknown date field '{date_field}'.") from exc
+            if not isinstance(field, (models.DateField, models.DateTimeField)):
+                raise ValueError(f"Field '{date_field}' is not a date field.")
+            after = request.GET.get("date_after")
+            before = request.GET.get("date_before")
+            if after:
+                parsed_after = self._parse_datetime(after, end_of_day=False)
+                if parsed_after is None:
+                    raise ValueError("`date_after` must be a valid ISO formatted date/time value.")
+                filter_kwargs[f"{date_field}__gte"] = parsed_after
+            if before:
+                parsed_before = self._parse_datetime(before, end_of_day=True)
+                if parsed_before is None:
+                    raise ValueError("`date_before` must be a valid ISO formatted date/time value.")
+                filter_kwargs[f"{date_field}__lte"] = parsed_before
+
+        if filter_kwargs:
+            queryset = queryset.filter(**filter_kwargs)
+        return queryset
+
+    def _parse_datetime(self, raw_value: str, *, end_of_day: bool) -> datetime | None:
+        parsed = parse_datetime(raw_value)
+        if parsed is None:
+            date_value = parse_date(raw_value)
+            if date_value is None:
+                return None
+            if end_of_day:
+                parsed = datetime.combine(date_value, datetime.max.time())
+            else:
+                parsed = datetime.combine(date_value, datetime.min.time())
+        if timezone.is_naive(parsed):
+            try:
+                parsed = timezone.make_aware(parsed, timezone.get_current_timezone())
+            except Exception:  # pragma: no cover - fallback for already aware values
+                return parsed
+        return parsed
+
+    def _paginate(self, request, matches):
+        page_size = self._get_page_size(request)
+        if not matches:
+            return page_size, None, None
+
+        paginator = Paginator(matches, page_size)
+        page_number = self._get_page_number(request)
+        try:
+            page_obj = paginator.page(page_number)
+        except (EmptyPage, PageNotAnInteger):
+            page_obj = paginator.page(paginator.num_pages)
+        return page_size, paginator, page_obj
+
+    def _get_page_size(self, request) -> int:
+        size = self._parse_positive_int(request.GET.get("page_size"), default=25)
+        if size is None:
+            raise ValueError("`page_size` must be a positive integer.")
+        return min(size, 200)
+
+    def _get_page_number(self, request) -> int:
+        page_number = self._parse_positive_int(request.GET.get("page"), default=1)
+        if page_number is None:
+            raise ValueError("`page` must be a positive integer.")
+        return page_number
+
+    def _parse_positive_int(self, raw_value: str | None, *, default: int | None) -> int | None:
+        if raw_value in (None, ""):
+            return default
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None
+        if value <= 0:
+            return None
+        return value
+
+    def _serialise_match(self, match, fields: list[str]) -> dict[str, Any]:
+        preview = []
+        for field_name in fields:
+            value = getattr(match.instance, field_name, "")
+            preview.append({"field": field_name, "value": "" if value is None else str(value)})
+
+        return {
+            "score": round(match.score, 2),
+            "candidate": {
+                "pk": match.instance.pk,
+                "label": str(match.instance),
+            },
+            "preview": preview,
+        }
 
 class PreparationAccessMixin(UserPassesTestMixin):
     def test_func(self):


### PR DESCRIPTION
## Summary
- extend the merge fuzzy helpers with ordered scoring support
- add a staff-only merge candidate search API with pagination, filters, and admin template
- provide W3.CSS templates and JavaScript to drive the interactive merge selection UI

## Testing
- python -m compileall app/cms/merge/fuzzy.py app/cms/views.py

------
https://chatgpt.com/codex/tasks/task_e_68e63dcda8648329b715ad38f64c14b0