### PR TITLE
Integrate merge workflow into admin for mergeable models

### DIFF
--- a/app/cms/admin.py
+++ b/app/cms/admin.py
@@ -8,6 +8,7 @@ from import_export.widgets import ForeignKeyWidget, DateWidget
 from simple_history.admin import SimpleHistoryAdmin
 
 from .forms import AccessionNumberSeriesAdminForm, DrawerRegisterForm
+from .admin_merge import MergeAdminMixin
 from .merge import merge_records
 
 from .models import (
@@ -288,7 +289,7 @@ class ElementAdmin(HistoricalImportExportAdmin):
     ordering = ('name',)
 
 # FieldSlip Model
-class FieldSlipAdmin(MergeAdminActionMixin, HistoricalImportExportAdmin):
+class FieldSlipAdmin(MergeAdminActionMixin, MergeAdminMixin, HistoricalImportExportAdmin):
     resource_class = FieldSlipResource
     list_display = ('field_number', 'discoverer', 'collector', 'collection_date', 'verbatim_locality', 'verbatim_taxon', 'verbatim_element')
     search_fields = ('field_number', 'discoverer', 'collector', 'verbatim_locality')
@@ -591,7 +592,7 @@ class PersonAdmin(HistoricalImportExportAdmin):
     search_fields = ('first_name', 'last_name', 'orcid')
 
 # Reference Model
-class ReferenceAdmin(MergeAdminActionMixin, HistoricalImportExportAdmin):
+class ReferenceAdmin(MergeAdminActionMixin, MergeAdminMixin, HistoricalImportExportAdmin):
     resource_class = ReferenceResource
     list_display = ('citation', 'doi')
     search_fields = ('citation', 'doi')
@@ -603,7 +604,7 @@ class SpecimenGeologyAdmin(HistoricalImportExportAdmin):
     ordering = ('accession',)
 
 # Storage Model
-class StorageAdmin(MergeAdminActionMixin, HistoricalImportExportAdmin):
+class StorageAdmin(MergeAdminActionMixin, MergeAdminMixin, HistoricalImportExportAdmin):
     resource_class = StorageResource
     list_display = ('area', 'parent_area')
     search_fields = ('area', 'parent_area__area')

--- a/app/cms/admin_merge.py
+++ b/app/cms/admin_merge.py
@@ -1,0 +1,457 @@
+"""Admin integration helpers for managing merge workflows."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Mapping
+
+from django import forms
+from django.contrib import admin, messages
+from django.contrib.admin.utils import display_for_field
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import redirect, render
+from django.urls import path, reverse
+from django.utils.translation import gettext_lazy as _
+
+from .merge import merge_records
+from .merge.constants import MERGE_STRATEGY_CHOICES, MergeStrategy
+
+
+def manual_value_strategy(
+    *,
+    field_name: str,
+    target: models.Model,
+    options: Mapping[str, Any],
+    **_: Any,
+) -> Any:
+    """Return a value resolved from a manual prompt for the given ``field_name``."""
+
+    value = options.get("value")
+    try:
+        field = target._meta.get_field(field_name)  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - defensive guard
+        return value
+
+    if isinstance(field, models.ForeignKey):
+        if value in (None, ""):
+            return None
+        return field.remote_field.model._default_manager.get(pk=value)
+
+    return value
+
+
+class MergeAdminForm(forms.Form):
+    """Form rendered by :class:`MergeAdminMixin` to configure merges."""
+
+    selected_ids = forms.CharField(required=False, widget=forms.HiddenInput)
+    source = forms.CharField(required=True, widget=forms.HiddenInput)
+    target = forms.CharField(required=True, widget=forms.HiddenInput)
+
+    strategy_prefix = "strategy__"
+    value_prefix = "value__"
+
+    def __init__(
+        self,
+        *,
+        model: type[models.Model],
+        merge_fields: Iterable[models.Field],
+        data: Mapping[str, Any] | None = None,
+        initial: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.model = model
+        self._merge_fields: List[models.Field] = list(merge_fields)
+        self.field_configs: list[dict[str, Any]] = []
+        super().__init__(data=data, initial=initial)
+
+        for field in self._merge_fields:
+            strategy_name = self.strategy_field_name(field.name)
+            manual_name = self.value_field_name(field.name)
+
+            default_strategy = MergeStrategy.PREFER_NON_NULL
+            if hasattr(model, "get_merge_strategy_for_field"):
+                raw_default = model.get_merge_strategy_for_field(field.name)
+                try:
+                    default_strategy = (
+                        raw_default
+                        if isinstance(raw_default, MergeStrategy)
+                        else MergeStrategy(raw_default)
+                    )
+                except ValueError:
+                    default_strategy = MergeStrategy.PREFER_NON_NULL
+
+            self.fields[strategy_name] = forms.ChoiceField(
+                choices=MERGE_STRATEGY_CHOICES,
+                initial=default_strategy.value,
+                label=field.verbose_name,
+            )
+
+            manual_field = field.formfield(required=False)
+            if manual_field is None:
+                manual_field = forms.CharField(required=False, label=field.verbose_name)
+            manual_field.widget.attrs.setdefault("class", "vTextField")
+            manual_field.label = _("Manual value")
+            self.fields[manual_name] = manual_field
+
+            self.field_configs.append(
+                {
+                    "field": field,
+                    "strategy_name": strategy_name,
+                    "value_name": manual_name,
+                }
+            )
+
+    @classmethod
+    def strategy_field_name(cls, field_name: str) -> str:
+        return f"{cls.strategy_prefix}{field_name}"
+
+    @classmethod
+    def value_field_name(cls, field_name: str) -> str:
+        return f"{cls.value_prefix}{field_name}"
+
+    def clean_source(self) -> models.Model:
+        return self._clean_object_field("source")
+
+    def clean_target(self) -> models.Model:
+        return self._clean_object_field("target")
+
+    def _clean_object_field(self, field_name: str) -> models.Model:
+        raw_value = self.cleaned_data.get(field_name)
+        if not raw_value:
+            raise ValidationError(_("Select a record."))
+        try:
+            return self.model._default_manager.get(pk=raw_value)
+        except self.model.DoesNotExist as exc:  # type: ignore[attr-defined]
+            raise ValidationError(_("Selected record no longer exists.")) from exc
+
+    def clean(self) -> Mapping[str, Any]:
+        cleaned_data = super().clean()
+
+        source = cleaned_data.get("source")
+        target = cleaned_data.get("target")
+        if source and target and getattr(source, "pk", None) == getattr(target, "pk", None):
+            raise ValidationError(_("Source and target must be different records."))
+
+        raw_ids = cleaned_data.get("selected_ids") or ""
+        self.selected_ids = [value for value in (item.strip() for item in raw_ids.split(",")) if value]
+
+        for config in self.field_configs:
+            strategy_name = config["strategy_name"]
+            value_name = config["value_name"]
+            raw_strategy = cleaned_data.get(strategy_name)
+            if not raw_strategy:
+                continue
+            try:
+                strategy = MergeStrategy(raw_strategy)
+            except ValueError as exc:  # pragma: no cover - defensive guard
+                raise ValidationError(_("Unknown merge strategy specified.")) from exc
+
+            cleaned_data[strategy_name] = strategy.value
+            if strategy is MergeStrategy.USER_PROMPT:
+                manual_value = cleaned_data.get(value_name)
+                if manual_value in (None, ""):
+                    self.add_error(
+                        value_name,
+                        _("Provide a value when using the USER_PROMPT strategy."),
+                    )
+                elif isinstance(manual_value, models.Model):
+                    cleaned_data[value_name] = manual_value.pk
+
+        return cleaned_data
+
+    def build_strategy_map(self) -> dict[str, Any]:
+        """Return a strategy payload suitable for :func:`merge_records`."""
+
+        strategies: dict[str, Any] = {"fields": {}}
+        for config in self.field_configs:
+            field = config["field"]
+            field_name = field.name
+            strategy_value = self.cleaned_data.get(config["strategy_name"])
+            if not strategy_value:
+                continue
+
+            strategy = MergeStrategy(strategy_value)
+            if strategy is MergeStrategy.USER_PROMPT:
+                manual_value = self.cleaned_data.get(config["value_name"])
+                strategies["fields"][field_name] = {
+                    "strategy": MergeStrategy.CUSTOM.value,
+                    "callback": manual_value_strategy,
+                    "value": manual_value,
+                }
+            else:
+                strategies["fields"][field_name] = strategy.value
+
+        return strategies
+
+    def get_bound_instance(self, role: str) -> models.Model | None:
+        """Return the instance currently selected for ``role`` (source/target)."""
+
+        value = self.data.get(role) if self.is_bound else self.initial.get(role)
+        if not value:
+            return None
+        try:
+            return self.model._default_manager.get(pk=value)
+        except self.model.DoesNotExist:  # type: ignore[attr-defined]
+            return None
+
+
+class MergeAdminMixin:
+    """Reusable admin mixin exposing merge tooling within the Django admin."""
+
+    merge_template = "admin/cms/merge/merge_form.html"
+    merge_form_class = MergeAdminForm
+
+    class Media:
+        css = {"all": ("cms/css/merge_admin.css",)}
+        js = ("cms/js/merge_admin.js",)
+
+    @admin.action(description=_("Merge selected records"))
+    def merge_selected(self, request, queryset):  # type: ignore[override]
+        if not self.has_merge_permission(request):
+            self.message_user(
+                request,
+                _("You do not have permission to merge records."),
+                level=messages.ERROR,
+            )
+            return None
+
+        selected = request.POST.getlist(admin.ACTION_CHECKBOX_NAME)
+        if len(selected) < 2:
+            self.message_user(
+                request,
+                _("Select at least two records to start a merge."),
+                level=messages.WARNING,
+            )
+            return None
+
+        info = self.model._meta.app_label, self.model._meta.model_name
+        url = reverse(f"admin:{info[0]}_{info[1]}_merge")
+        return HttpResponseRedirect(f"{url}?ids={','.join(selected)}")
+
+    def get_actions(self, request):  # type: ignore[override]
+        actions = super().get_actions(request)
+        if not self.has_merge_permission(request):
+            actions.pop("merge_selected", None)
+        return actions
+
+    def has_merge_permission(self, request: HttpRequest) -> bool:
+        opts = self.model._meta
+        return request.user.has_perm(f"{opts.app_label}.can_merge")
+
+    def get_mergeable_fields(self) -> list[models.Field]:
+        fields: list[models.Field] = []
+        for field in self.model._meta.concrete_fields:  # type: ignore[attr-defined]
+            if field.primary_key or not getattr(field, "editable", False):
+                continue
+            fields.append(field)
+        return fields
+
+    def get_urls(self):  # type: ignore[override]
+        urls = super().get_urls()
+        info = self.model._meta.app_label, self.model._meta.model_name
+        custom = [
+            path(
+                "merge/",
+                self.admin_site.admin_view(self.merge_view),
+                name=f"{info[0]}_{info[1]}_merge",
+            ),
+        ]
+        return custom + urls
+
+    def merge_view(self, request: HttpRequest) -> HttpResponse:
+        if not self.has_merge_permission(request):
+            self.message_user(
+                request,
+                _("You do not have permission to merge records."),
+                level=messages.ERROR,
+            )
+            info = self.model._meta.app_label, self.model._meta.model_name
+            return redirect(f"admin:{info[0]}_{info[1]}_changelist")
+
+        merge_fields = self.get_mergeable_fields()
+        selected_ids = self._extract_selected_ids(request)
+
+        initial_source = request.GET.get("source") or (selected_ids[1] if len(selected_ids) > 1 else "")
+        initial_target = request.GET.get("target") or (selected_ids[0] if selected_ids else "")
+
+        if request.method == "POST":
+            form = self.merge_form_class(
+                model=self.model,
+                merge_fields=merge_fields,
+                data=request.POST,
+            )
+        else:
+            initial: dict[str, Any] = {"selected_ids": ",".join(selected_ids)}
+            if initial_source:
+                initial["source"] = initial_source
+            if initial_target:
+                initial["target"] = initial_target
+
+            target_obj = self._get_object_or_none(initial_target)
+            if target_obj is not None:
+                for field in merge_fields:
+                    initial[self.merge_form_class.value_field_name(field.name)] = getattr(
+                        target_obj, field.name
+                    )
+
+            form = self.merge_form_class(
+                model=self.model,
+                merge_fields=merge_fields,
+                initial=initial,
+            )
+
+        source_obj = form.get_bound_instance("source")
+        target_obj = form.get_bound_instance("target")
+
+        if request.method == "POST" and form.is_valid():
+            try:
+                merge_result = merge_records(
+                    form.cleaned_data["source"],
+                    form.cleaned_data["target"],
+                    form.build_strategy_map(),
+                    user=request.user,
+                )
+            except Exception as exc:  # pragma: no cover - surfaced to admin UI
+                self.message_user(request, str(exc), level=messages.ERROR)
+            else:
+                target = merge_result.target
+                source = form.cleaned_data["source"]
+                self.log_change(
+                    request,
+                    target,
+                    f"Merged {source.pk} into {target.pk}",
+                )
+                self.message_user(
+                    request,
+                    _("Merged %(source)s into %(target)s (%(count)s fields updated).")
+                    % {
+                        "source": source,
+                        "target": target,
+                        "count": len(merge_result.resolved_values),
+                    },
+                    level=messages.SUCCESS,
+                )
+                info = self.model._meta.app_label, self.model._meta.model_name
+                return redirect(f"admin:{info[0]}_{info[1]}_change", target.pk)
+
+        context = self._build_merge_context(
+            request,
+            form=form,
+            selected_ids=selected_ids,
+            source_obj=source_obj,
+            target_obj=target_obj,
+            merge_fields=merge_fields,
+        )
+        return render(request, self.merge_template, context)
+
+    def _extract_selected_ids(self, request: HttpRequest) -> list[str]:
+        raw = request.GET.get("ids") or request.POST.get("selected_ids") or ""
+        return [value for value in (item.strip() for item in raw.split(",")) if value]
+
+    def _get_object_or_none(self, pk: str | None) -> models.Model | None:
+        if not pk:
+            return None
+        try:
+            return self.model._default_manager.get(pk=pk)
+        except self.model.DoesNotExist:  # type: ignore[attr-defined]
+            return None
+
+    def _build_merge_context(
+        self,
+        request: HttpRequest,
+        *,
+        form: MergeAdminForm,
+        selected_ids: list[str],
+        source_obj: models.Model | None,
+        target_obj: models.Model | None,
+        merge_fields: Iterable[models.Field],
+    ) -> dict[str, Any]:
+        opts = self.model._meta
+        changelist_url = reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+
+        selected_objects = self._serialise_objects(selected_ids)
+
+        field_rows = []
+        for config in form.field_configs:
+            field = config["field"]
+            field_rows.append(
+                {
+                    "name": field.name,
+                    "label": field.verbose_name,
+                    "source": self._format_field_value(source_obj, field),
+                    "target": self._format_field_value(target_obj, field),
+                    "strategy": form[config["strategy_name"]],
+                    "manual": form[config["value_name"]],
+                }
+            )
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": opts,
+            "form": form,
+            "media": self.media + form.media,
+            "title": _(f"Merge {opts.verbose_name}"),
+            "field_rows": field_rows,
+            "selected_objects": selected_objects,
+            "source_summary": self._serialise_instance(source_obj),
+            "target_summary": self._serialise_instance(target_obj),
+            "changelist_url": changelist_url,
+            "search_url": reverse("merge_candidate_search"),
+            "model_label": f"{opts.app_label}.{opts.model_name}",
+        }
+        return context
+
+    def _serialise_objects(self, ids: Iterable[str]) -> list[dict[str, Any]]:
+        objects = self.model._default_manager.filter(pk__in=ids)
+        mapping = {str(obj.pk): obj for obj in objects}
+        ordered: list[dict[str, Any]] = []
+        for pk in ids:
+            obj = mapping.get(pk)
+            if obj is None:
+                continue
+            ordered.append(self._serialise_instance(obj))
+        return ordered
+
+    def _serialise_instance(self, obj: models.Model | None) -> dict[str, Any] | None:
+        if obj is None:
+            return None
+        preview = []
+        if hasattr(obj, "get_merge_display_fields"):
+            try:
+                field_names = list(obj.get_merge_display_fields())
+            except Exception:  # pragma: no cover - defensive
+                field_names = []
+        else:
+            field_names = []
+
+        for name in field_names:
+            try:
+                field = obj._meta.get_field(name)  # type: ignore[attr-defined]
+                value = getattr(obj, name, None)
+                preview.append(
+                    {
+                        "field": field.verbose_name,
+                        "value": self._format_field_value(obj, field),
+                    }
+                )
+            except Exception:
+                value = getattr(obj, name, None)
+                preview.append({"field": name, "value": "" if value is None else str(value)})
+
+        return {
+            "pk": obj.pk,
+            "label": str(obj),
+            "preview": preview,
+        }
+
+    def _format_field_value(self, obj: models.Model | None, field: models.Field) -> str:
+        if obj is None:
+            return "—"
+        value = getattr(obj, field.name, None)
+        if value in (None, ""):
+            return "—"
+        try:
+            return str(display_for_field(value, field))
+        except Exception:  # pragma: no cover - safety net
+            return str(value)
+

--- a/app/cms/static/css/merge_admin.css
+++ b/app/cms/static/css/merge_admin.css
@@ -1,0 +1,131 @@
+.merge-admin {
+  max-width: 1100px;
+}
+
+.merge-admin__title {
+  margin-bottom: 1.5rem;
+}
+
+.merge-admin__intro {
+  margin-bottom: 2rem;
+}
+
+.merge-admin__selection {
+  margin-bottom: 2rem;
+}
+
+.merge-admin__selection-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.merge-admin__selection-column {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.merge-admin__selection-label {
+  font-weight: 600;
+}
+
+.merge-admin__badge {
+  display: inline-block;
+  margin-left: 0.5rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  background-color: #f0f0f0;
+  font-size: 0.85em;
+}
+
+.merge-admin__empty {
+  color: #777;
+}
+
+.merge-admin__cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.merge-admin__card {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+  background: #fff;
+}
+
+.merge-admin__card-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.merge-admin__preview {
+  margin: 0.5rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.merge-admin__search-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.merge-admin__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.merge-admin__results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.merge-admin__notice,
+.merge-admin__error {
+  margin: 0;
+}
+
+.merge-admin__errors {
+  margin-bottom: 1rem;
+  color: #ba2121;
+}
+
+.merge-admin__table-wrapper {
+  overflow-x: auto;
+}
+
+.merge-admin__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.merge-admin__table th,
+.merge-admin__table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  vertical-align: top;
+}
+
+.merge-admin__table thead th {
+  background-color: #f5f5f5;
+}
+
+.merge-admin__field-error {
+  color: #ba2121;
+  margin-top: 0.4rem;
+}
+
+.merge-admin__field-control[hidden] {
+  display: none;
+}
+
+.merge-admin__value {
+  font-family: monospace;
+}

--- a/app/cms/static/js/merge_admin.js
+++ b/app/cms/static/js/merge_admin.js
@@ -1,0 +1,171 @@
+(function () {
+  const container = document.querySelector('[data-merge-admin]');
+  if (!container) {
+    return;
+  }
+
+  const searchForm = container.querySelector('[data-merge-search-form]');
+  const resultsContainer = container.querySelector('[data-merge-results]');
+  const searchUrl = container.dataset.searchUrl;
+  const modelLabel = container.dataset.modelLabel;
+  const idsField = container.querySelector('input[name="selected_ids"]');
+
+  const updateLocation = (role, pk) => {
+    const url = new URL(window.location.href);
+    if (pk) {
+      url.searchParams.set(role, pk);
+    } else {
+      url.searchParams.delete(role);
+    }
+    if (idsField && idsField.value) {
+      url.searchParams.set('ids', idsField.value);
+    }
+    window.location.href = url.toString();
+  };
+
+  container.querySelectorAll('[data-merge-set-role]').forEach((button) => {
+    button.addEventListener('click', (event) => {
+      event.preventDefault();
+      const role = button.dataset.mergeSetRole;
+      const pk = button.dataset.mergeObjectId;
+      if (!role || !pk) {
+        return;
+      }
+      updateLocation(role, pk);
+    });
+  });
+
+  const escapeSelector = (value) => {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return value.replace(/([^a-zA-Z0-9_-])/g, '\\$1');
+  };
+
+  const toggleManualInputs = () => {
+    container.querySelectorAll('[data-merge-strategy-container]').forEach((wrapper) => {
+      const select = wrapper.querySelector('select');
+      if (!select) {
+        return;
+      }
+      const name = select.name || '';
+      const fieldName = name.replace(/^strategy__/, '');
+      const manualWrapper = container.querySelector(
+        `[data-merge-manual-field="${escapeSelector(fieldName)}"]`
+      );
+      if (!manualWrapper) {
+        return;
+      }
+      if (select.value === 'user_prompt') {
+        manualWrapper.removeAttribute('hidden');
+      } else {
+        manualWrapper.setAttribute('hidden', 'hidden');
+      }
+    });
+  };
+
+  container.addEventListener('change', (event) => {
+    if (event.target && event.target.matches('[data-merge-strategy-container] select')) {
+      toggleManualInputs();
+    }
+  });
+  toggleManualInputs();
+
+  const renderResults = (payload) => {
+    if (!resultsContainer) {
+      return;
+    }
+    if (!payload || !Array.isArray(payload.results) || payload.results.length === 0) {
+      resultsContainer.innerHTML = '<p class="merge-admin__notice">No candidates found.</p>';
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    payload.results.forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'merge-admin__card';
+
+      const header = document.createElement('header');
+      const title = document.createElement('h3');
+      title.textContent = `${item.candidate.label || 'Candidate'} (ID ${item.candidate.pk})`;
+      header.appendChild(title);
+      card.appendChild(header);
+
+      if (Array.isArray(item.preview) && item.preview.length) {
+        const previewList = document.createElement('ul');
+        previewList.className = 'merge-admin__preview';
+        item.preview.forEach((row) => {
+          const li = document.createElement('li');
+          li.innerHTML = `<strong>${row.field}:</strong> ${row.value || ''}`;
+          previewList.appendChild(li);
+        });
+        card.appendChild(previewList);
+      }
+
+      const actions = document.createElement('div');
+      actions.className = 'merge-admin__card-actions';
+
+      const targetButton = document.createElement('button');
+      targetButton.type = 'button';
+      targetButton.className = 'button';
+      targetButton.textContent = 'Use as target';
+      targetButton.addEventListener('click', () => updateLocation('target', item.candidate.pk));
+      actions.appendChild(targetButton);
+
+      const sourceButton = document.createElement('button');
+      sourceButton.type = 'button';
+      sourceButton.className = 'button';
+      sourceButton.textContent = 'Use as source';
+      sourceButton.addEventListener('click', () => updateLocation('source', item.candidate.pk));
+      actions.appendChild(sourceButton);
+
+      card.appendChild(actions);
+      fragment.appendChild(card);
+    });
+
+    resultsContainer.innerHTML = '';
+    resultsContainer.appendChild(fragment);
+  };
+
+  if (searchForm && searchUrl) {
+    searchForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(searchForm);
+      const query = (formData.get('query') || '').toString().trim();
+      if (!query) {
+        if (resultsContainer) {
+          resultsContainer.innerHTML = '<p class="merge-admin__notice">Enter a search term to continue.</p>';
+        }
+        return;
+      }
+
+      const params = new URLSearchParams();
+      params.set('model_label', modelLabel);
+      params.set('query', query);
+      const threshold = (formData.get('threshold') || '').toString().trim();
+      if (threshold) {
+        params.set('threshold', threshold);
+      }
+
+      if (resultsContainer) {
+        resultsContainer.innerHTML = '<p class="merge-admin__notice">Searching…</p>';
+      }
+
+      fetch(`${searchUrl}?${params.toString()}`)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Request failed');
+          }
+          return response.json();
+        })
+        .then((payload) => {
+          renderResults(payload);
+        })
+        .catch(() => {
+          if (resultsContainer) {
+            resultsContainer.innerHTML = '<p class="merge-admin__error">Unable to load merge candidates.</p>';
+          }
+        });
+    });
+  }
+})();

--- a/app/cms/templates/admin/cms/merge/merge_form.html
+++ b/app/cms/templates/admin/cms/merge/merge_form.html
@@ -1,0 +1,148 @@
+{% extends "admin/change_form.html" %}
+{% load i18n static %}
+
+{% block content %}
+<div class="merge-admin" data-merge-admin data-search-url="{{ search_url }}" data-model-label="{{ model_label }}">
+  <h1 class="merge-admin__title">{{ title }}</h1>
+
+  <div class="merge-admin__intro">
+    <p>{% trans "Use this tool to review and merge duplicate records. Select a source and target, choose strategies for each field, then confirm the merge." %}</p>
+  </div>
+
+  <section class="merge-admin__selection">
+    <h2>{% trans "Current selection" %}</h2>
+    <div class="merge-admin__selection-grid">
+      <div class="merge-admin__selection-column">
+        <h3>{% trans "Target" %}</h3>
+        {% if target_summary %}
+          <p class="merge-admin__selection-label" data-merge-summary="target">{{ target_summary.label }} <span class="merge-admin__badge">ID {{ target_summary.pk }}</span></p>
+          {% if target_summary.preview %}
+            <ul class="merge-admin__preview">
+              {% for row in target_summary.preview %}
+                <li><strong>{{ row.field }}:</strong> {{ row.value }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% else %}
+          <p class="merge-admin__empty" data-merge-summary="target">{% trans "No target selected." %}</p>
+        {% endif %}
+      </div>
+      <div class="merge-admin__selection-column">
+        <h3>{% trans "Source" %}</h3>
+        {% if source_summary %}
+          <p class="merge-admin__selection-label" data-merge-summary="source">{{ source_summary.label }} <span class="merge-admin__badge">ID {{ source_summary.pk }}</span></p>
+          {% if source_summary.preview %}
+            <ul class="merge-admin__preview">
+              {% for row in source_summary.preview %}
+                <li><strong>{{ row.field }}:</strong> {{ row.value }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        {% else %}
+          <p class="merge-admin__empty" data-merge-summary="source">{% trans "No source selected." %}</p>
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  {% if selected_objects %}
+  <section class="merge-admin__selection">
+    <h2>{% trans "Selected from list" %}</h2>
+    <div class="merge-admin__cards">
+      {% for item in selected_objects %}
+      <article class="merge-admin__card">
+        <header>
+          <h3>{{ item.label }}</h3>
+          <p class="merge-admin__badge">ID {{ item.pk }}</p>
+        </header>
+        {% if item.preview %}
+        <ul class="merge-admin__preview">
+          {% for row in item.preview %}
+          <li><strong>{{ row.field }}:</strong> {{ row.value }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+        <div class="merge-admin__card-actions">
+          <button type="button" class="button" data-merge-set-role="target" data-merge-object-id="{{ item.pk }}">{% trans "Use as target" %}</button>
+          <button type="button" class="button" data-merge-set-role="source" data-merge-object-id="{{ item.pk }}">{% trans "Use as source" %}</button>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  <section class="merge-admin__search">
+    <h2>{% trans "Search for candidates" %}</h2>
+    <form class="merge-admin__search-form" data-merge-search-form>
+      <div class="merge-admin__field">
+        <label for="merge-search-query">{% trans "Search term" %}</label>
+        <input type="search" id="merge-search-query" name="query" placeholder="{% trans 'e.g. specimen number or title' %}" required>
+      </div>
+      <div class="merge-admin__field">
+        <label for="merge-search-threshold">{% trans "Match threshold" %}</label>
+        <input type="number" id="merge-search-threshold" name="threshold" min="0" max="100" step="1" value="75">
+      </div>
+      <div class="merge-admin__actions">
+        <button type="submit" class="button button-primary">{% trans "Search" %}</button>
+      </div>
+    </form>
+    <div class="merge-admin__results" data-merge-results></div>
+  </section>
+
+  <form method="post" novalidate class="merge-admin__form">
+    {% csrf_token %}
+    {{ form.selected_ids }}
+    {{ form.source }}
+    {{ form.target }}
+
+    {% if form.non_field_errors %}
+      <div class="merge-admin__errors">{{ form.non_field_errors }}</div>
+    {% endif %}
+
+    <div class="merge-admin__table-wrapper">
+      <table class="merge-admin__table">
+        <thead>
+          <tr>
+            <th>{% trans "Field" %}</th>
+            <th>{% trans "Source value" %}</th>
+            <th>{% trans "Target value" %}</th>
+            <th>{% trans "Strategy" %}</th>
+            <th>{% trans "Manual value" %}</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for row in field_rows %}
+          <tr>
+            <th scope="row">{{ row.label }}</th>
+            <td class="merge-admin__value">{{ row.source }}</td>
+            <td class="merge-admin__value">{{ row.target }}</td>
+            <td>
+              <div class="merge-admin__field-control" data-merge-strategy-container>
+                {{ row.strategy }}
+              </div>
+              {% if row.strategy.errors %}
+                <div class="merge-admin__field-error">{{ row.strategy.errors }}</div>
+              {% endif %}
+            </td>
+            <td>
+              <div class="merge-admin__field-control" data-merge-manual-field="{{ row.name }}" hidden>
+                {{ row.manual }}
+              </div>
+              {% if row.manual.errors %}
+                <div class="merge-admin__field-error">{{ row.manual.errors }}</div>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="submit-row">
+      <button type="submit" class="button button-primary">{% trans "Merge records" %}</button>
+      <a href="{{ changelist_url }}" class="button cancel-link">{% trans "Cancel" %}</a>
+    </div>
+  </form>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable MergeAdminMixin and form that expose merge configuration, enforce user prompt validation, and log results through the existing merge engine
- connect Django admin to the mixin with a dedicated merge template plus JavaScript and CSS assets for search, comparison, and strategy controls
- apply the mixin to FieldSlip, Reference, and Storage admin classes while preserving existing import/export behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e645d5eef48329bc5a3da101a995cd