### PR TITLE
Add merge engine integration tests and admin documentation

### DIFF
--- a/app/cms/tests/test_admin_merge.py
+++ b/app/cms/tests/test_admin_merge.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from django.contrib import admin
+from django.contrib.admin.helpers import ACTION_CHECKBOX_NAME
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.db import connection, models
+from django.http import HttpResponseRedirect
+from django.test import RequestFactory, TransactionTestCase, override_settings
+from django.test.utils import isolate_apps
+from django.urls import path
+from unittest.mock import patch
+
+from cms.admin_merge import MergeAdminMixin
+from cms.merge.constants import MergeStrategy
+from cms.merge.mixins import MergeMixin
+from cms.models import MergeLog
+
+
+test_admin_site = AdminSite(name="merge-admin-test")
+urlpatterns = [path("admin/", test_admin_site.urls)]
+
+
+@isolate_apps("cms")
+@override_settings(ROOT_URLCONF="cms.tests.test_admin_merge")
+class MergeAdminWorkflowTests(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        class MergeableRecord(MergeMixin):
+            name = models.CharField(max_length=64)
+            email = models.EmailField(blank=True)
+            notes = models.TextField(blank=True)
+
+            merge_fields = {
+                "name": MergeStrategy.LAST_WRITE,
+                "email": MergeStrategy.PREFER_NON_NULL,
+            }
+
+            class Meta:
+                app_label = "cms"
+
+            def __str__(self) -> str:
+                return self.name
+
+        class MergeableRecordAdmin(MergeAdminMixin, admin.ModelAdmin):
+            list_display = ("name", "email")
+
+        cls.Model = MergeableRecord
+        cls.Admin = MergeableRecordAdmin
+
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.create_model(MergeableRecord)
+        finally:
+            connection.enable_constraint_checking()
+
+        test_admin_site.register(MergeableRecord, MergeableRecordAdmin)
+
+        model_admin = test_admin_site._registry[MergeableRecord]
+        cls.app_label = model_admin.opts.app_label
+        cls.model_name = model_admin.opts.model_name
+        cls.changelist_url = f"/admin/{cls.app_label}/{cls.model_name}/"
+        cls.merge_url = f"/admin/{cls.app_label}/{cls.model_name}/merge/"
+        cls.admin_site = test_admin_site
+        cls.model_admin = model_admin
+        setattr(admin, "ACTION_CHECKBOX_NAME", ACTION_CHECKBOX_NAME)
+
+        content_type = ContentType.objects.get_for_model(MergeableRecord)
+        cls.merge_permission, _ = Permission.objects.get_or_create(
+            codename="can_merge",
+            name="Can merge mergeable records",
+            content_type=content_type,
+        )
+        cls.UserModel = get_user_model()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.admin_site.unregister(cls.Model)
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.delete_model(cls.Model)
+        finally:
+            connection.enable_constraint_checking()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.target = self.Model.objects.create(
+            name="Target",
+            email="target@example.com",
+            notes="Keep",
+        )
+        self.source = self.Model.objects.create(
+            name="Source",
+            email="",
+            notes="",
+        )
+
+        self.model_admin = self.__class__.model_admin
+        self.factory = RequestFactory()
+
+    def _login(self, *, with_permission: bool):
+        user = self.UserModel.objects.create_user(
+            username="merge-user" if with_permission else "limited-user",
+            password="pass",
+            is_staff=True,
+        )
+        if with_permission:
+            user.user_permissions.add(self.merge_permission)
+        return user
+
+    def _build_request(self, method: str, path: str, *, data: dict[str, str] | None = None, user=None):
+        factory = self.factory
+        request = getattr(factory, method)(path, data=data or {})
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        setattr(request, "_messages", FallbackStorage(request))
+        request._dont_enforce_csrf_checks = True
+        request.user = user
+        return request
+
+    def test_merge_action_requires_permission(self):
+        user = self._login(with_permission=False)
+        changelist_request = self._build_request("get", self.changelist_url, user=user)
+
+        actions = self.model_admin.get_actions(changelist_request)
+        self.assertNotIn("merge_selected", actions)
+
+        merge_request = self._build_request(
+            "get",
+            f"{self.merge_url}?ids={self.target.pk},{self.source.pk}",
+            user=user,
+        )
+        with self._override_admin_urls():
+            response = self.admin_site.admin_view(self.model_admin.merge_view)(merge_request)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(self.changelist_url, response["Location"])
+
+    def test_admin_merge_workflow_executes_merge(self):
+        user = self._login(with_permission=True)
+
+        post_data = {
+            "action": "merge_selected",
+            ACTION_CHECKBOX_NAME: [str(self.target.pk), str(self.source.pk)],
+        }
+        queryset = self.Model._default_manager.filter(pk__in=[self.target.pk, self.source.pk])
+        action_request = self._build_request("post", self.changelist_url, data=post_data, user=user)
+        with self._override_admin_urls():
+            response = self.model_admin.merge_selected(action_request, queryset)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(self.merge_url, response["Location"])
+
+        form_data = {
+            "selected_ids": f"{self.target.pk},{self.source.pk}",
+            "source": str(self.source.pk),
+            "target": str(self.target.pk),
+            "strategy__name": MergeStrategy.LAST_WRITE.value,
+            "value__name": "",
+            "strategy__email": MergeStrategy.PREFER_NON_NULL.value,
+            "value__email": "",
+            "strategy__notes": MergeStrategy.PREFER_NON_NULL.value,
+            "value__notes": "",
+        }
+        merge_request = self._build_request("post", self.merge_url, data=form_data, user=user)
+        with self._override_admin_urls():
+            response = self.admin_site.admin_view(self.model_admin.merge_view)(merge_request)
+        self.assertEqual(response.status_code, 302)
+
+        self.target.refresh_from_db()
+        self.assertEqual(self.target.name, "Source")
+        self.assertEqual(self.target.email, "target@example.com")
+
+        self.assertFalse(self.Model.objects.filter(pk=self.source.pk).exists())
+        self.assertTrue(MergeLog.objects.filter(target_pk=str(self.target.pk)).exists())
+    @contextmanager
+    def _override_admin_urls(self):
+        def resolve(name, *args, **kwargs):
+            if name == f"admin:{self.app_label}_{self.model_name}_merge":
+                return self.merge_url
+            if name == f"admin:{self.app_label}_{self.model_name}_changelist":
+                return self.changelist_url
+            if name == f"admin:{self.app_label}_{self.model_name}_change":
+                object_id = None
+                if args:
+                    object_id = args[0]
+                else:
+                    object_id = kwargs.get("object_id") or kwargs.get("pk")
+                return f"/admin/{self.app_label}/{self.model_name}/{object_id}/change/"
+            return name
+
+        with patch("cms.admin_merge.reverse", side_effect=resolve) as mock_reverse, patch(
+            "cms.admin_merge.redirect",
+            side_effect=lambda to, *args, **kwargs: HttpResponseRedirect(
+                resolve(to, *args, **kwargs) if isinstance(to, str) else to
+            ),
+        ):
+            yield mock_reverse

--- a/app/cms/tests/test_merge_engine.py
+++ b/app/cms/tests/test_merge_engine.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from django.db import connection, models
+from django.test import TransactionTestCase
+from django.test.utils import isolate_apps
+
+from cms.merge.constants import MergeStrategy
+from cms.merge.engine import merge_records
+from cms.merge.mixins import MergeMixin
+from cms.merge.serializers import serialize_instance
+from cms.models import MergeLog
+
+
+@isolate_apps("cms")
+class MergeEngineIntegrationTests(TransactionTestCase):
+    """Exercise the merge engine end-to-end using concrete models."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        class MergeSubject(MergeMixin):
+            title = models.CharField(max_length=64)
+            description = models.TextField(blank=True)
+            archived_snapshots = models.JSONField(default=list, blank=True)
+
+            merge_fields = {
+                "title": MergeStrategy.LAST_WRITE,
+                "description": {
+                    "strategy": MergeStrategy.PREFER_NON_NULL.value,
+                    "priority": ["source", "target"],
+                },
+            }
+
+            class Meta:
+                app_label = "cms"
+
+            def archive_source_instance(self, source_instance: "MergeSubject") -> None:  # type: ignore[name-defined]
+                snapshots = list(self.archived_snapshots or [])
+                snapshots.append(serialize_instance(source_instance))
+                self.archived_snapshots = snapshots
+                self.save(update_fields=["archived_snapshots"])
+
+        class Attachment(models.Model):
+            owner = models.ForeignKey(
+                MergeSubject,
+                related_name="attachments",
+                on_delete=models.CASCADE,
+            )
+            label = models.CharField(max_length=64)
+
+            class Meta:
+                app_label = "cms"
+
+        class Badge(models.Model):
+            name = models.CharField(max_length=64)
+            subjects = models.ManyToManyField(
+                MergeSubject,
+                related_name="badges",
+            )
+
+            class Meta:
+                app_label = "cms"
+
+        class Profile(models.Model):
+            owner = models.OneToOneField(
+                MergeSubject,
+                related_name="profile",
+                on_delete=models.CASCADE,
+            )
+            bio = models.CharField(max_length=128, blank=True)
+
+            class Meta:
+                app_label = "cms"
+
+        cls.MergeSubject = MergeSubject
+        cls.Attachment = Attachment
+        cls.Badge = Badge
+        cls.Profile = Profile
+
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.create_model(MergeSubject)
+                schema_editor.create_model(Attachment)
+                schema_editor.create_model(Badge)
+                schema_editor.create_model(Profile)
+        finally:
+            connection.enable_constraint_checking()
+
+    @classmethod
+    def tearDownClass(cls):
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.delete_model(cls.Profile)
+                schema_editor.delete_model(cls.Badge)
+                schema_editor.delete_model(cls.Attachment)
+                schema_editor.delete_model(cls.MergeSubject)
+        finally:
+            connection.enable_constraint_checking()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.target = self.MergeSubject.objects.create(
+            title="Target",
+            description="Existing description",
+        )
+        self.source = self.MergeSubject.objects.create(
+            title="Source",
+            description="Replacement description",
+        )
+
+        self.attachment = self.Attachment.objects.create(
+            owner=self.source,
+            label="Document",
+        )
+        self.profile = self.Profile.objects.create(owner=self.source, bio="Source bio")
+
+        self.shared_badge = self.Badge.objects.create(name="Shared")
+        self.shared_badge.subjects.add(self.source, self.target)
+        self.source_only_badge = self.Badge.objects.create(name="Source Only")
+        self.source_only_badge.subjects.add(self.source)
+
+    def test_merge_records_updates_fields_relations_and_logs(self):
+        source_pk = self.source.pk
+        result = merge_records(self.source, self.target, strategy_map=None, user=None)
+
+        self.target.refresh_from_db()
+        self.profile.refresh_from_db()
+        self.attachment.refresh_from_db()
+
+        self.assertEqual(self.target.title, "Source")
+        self.assertEqual(self.target.description, "Replacement description")
+
+        self.assertEqual(self.attachment.owner, self.target)
+        self.assertEqual(self.profile.owner, self.target)
+
+        badge_ids = sorted(self.target.badges.values_list("name", flat=True))
+        self.assertEqual(badge_ids, ["Shared", "Source Only"])
+
+        self.assertIn("title", result.resolved_values)
+        self.assertEqual(result.resolved_values["title"].value, "Source")
+        self.assertIn("description", result.resolved_values)
+        self.assertEqual(result.resolved_values["description"].value, "Replacement description")
+
+        relation_actions = result.relation_actions
+        self.assertEqual(relation_actions["attachments"]["updated"], 1)
+        self.assertEqual(relation_actions["profile"]["updated"], 1)
+        self.assertEqual(relation_actions["badges"]["added"], 1)
+        self.assertEqual(relation_actions["badges"]["skipped"], 1)
+
+        log_entry = MergeLog.objects.filter(target_pk=str(self.target.pk)).latest("executed_at")
+        self.assertEqual(log_entry.source_pk, str(source_pk))
+        self.assertEqual(log_entry.target_pk, str(self.target.pk))
+        self.assertEqual(log_entry.resolved_values["fields"]["title"]["value"], "Source")
+        self.assertEqual(log_entry.relation_actions["attachments"]["updated"], 1)
+        self.assertEqual(log_entry.relation_actions["badges"]["added"], 1)
+
+        self.target.refresh_from_db()
+        self.assertEqual(len(self.target.archived_snapshots), 1)
+        archived_snapshot = self.target.archived_snapshots[0]
+        self.assertEqual(archived_snapshot["title"], "Source")
+        self.assertEqual(archived_snapshot["description"], "Replacement description")
+
+        self.assertFalse(self.MergeSubject.objects.filter(pk=self.source.pk).exists())

--- a/app/cms/tests/test_merge_fuzzy_search.py
+++ b/app/cms/tests/test_merge_fuzzy_search.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.db import connection, models
+from django.test import TransactionTestCase
+from django.test.utils import isolate_apps
+from django.urls import reverse
+
+from cms.merge.mixins import MergeMixin
+from cms.merge.registry import MERGE_REGISTRY, register_merge_rules
+
+
+@isolate_apps("cms")
+class MergeCandidateAPITests(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        class Candidate(MergeMixin):
+            name = models.CharField(max_length=64)
+            city = models.CharField(max_length=64)
+
+            class Meta:
+                app_label = "cms"
+
+            def __str__(self) -> str:
+                return self.name
+
+        cls.Model = Candidate
+
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.create_model(Candidate)
+        finally:
+            connection.enable_constraint_checking()
+
+        cls._previous_registry_entry = MERGE_REGISTRY.get(Candidate)
+        register_merge_rules(Candidate)
+        cls.UserModel = get_user_model()
+
+    @classmethod
+    def tearDownClass(cls):
+        MERGE_REGISTRY.pop(cls.Model, None)
+        if cls._previous_registry_entry is not None:
+            MERGE_REGISTRY[cls.Model] = cls._previous_registry_entry
+        connection.disable_constraint_checking()
+        try:
+            with connection.schema_editor(atomic=False) as schema_editor:
+                schema_editor.delete_model(cls.Model)
+        finally:
+            connection.enable_constraint_checking()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.best = self.Model.objects.create(name="Alpha Beta", city="Nairobi")
+        self.partial = self.Model.objects.create(name="Alpha Gamma", city="Nakuru")
+        self.low = self.Model.objects.create(name="Delta Epsilon", city="Mombasa")
+        self.model_label = f"{self.Model._meta.app_label}.{self.Model._meta.model_name}"
+        self.url = reverse("merge_candidate_search")
+
+    def test_requires_staff_permissions(self):
+        params = {"model_label": self.model_label, "query": "Alpha", "fields": "name"}
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/admin/login/", response["Location"])
+
+        user = self.UserModel.objects.create_user(username="regular", password="pass", is_staff=False)
+        self.client.force_login(user)
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/admin/login/", response["Location"])
+
+    def test_threshold_filters_candidates(self):
+        staff = self.UserModel.objects.create_user(username="staff", password="pass", is_staff=True)
+        self.client.force_login(staff)
+
+        params = {
+            "model_label": self.model_label,
+            "query": "Alpha Beta",
+            "fields": "name",
+            "threshold": "70",
+        }
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual([result["candidate"]["pk"] for result in payload["results"]], [self.best.pk])
+
+        params["threshold"] = "50"
+        response = self.client.get(self.url, params)
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            [result["candidate"]["pk"] for result in payload["results"]],
+            [self.best.pk, self.partial.pk],
+        )

--- a/docs/admin/README.md
+++ b/docs/admin/README.md
@@ -8,3 +8,4 @@
 - [Preparations](preparations.md)
 - [Scan Uploads](scan-uploads.md)
 - [Users](users.md)
+- [Merge Tool](merge-tool.md)

--- a/docs/admin/merge-tool.md
+++ b/docs/admin/merge-tool.md
@@ -1,0 +1,60 @@
+# Merge Tool
+
+The merge tool lets authorised staff review duplicate records side-by-side and consolidate them into a single canonical entry. It relies on the `MergeAdminMixin` and merge engine that power automated logging and relation handling.
+
+## Prerequisites and Access Control
+
+1. Ensure the model is registered with the Django admin using `MergeAdminMixin` so the merge workflow, templates, and actions are available.
+2. Grant the **`can_merge`** permission for the model to the groups or users that should initiate merges. Users without the permission will not see the action and will be redirected back to the changelist if they attempt to access merge URLs.
+3. Users must be marked as staff members to access the admin and the merge candidate search endpoint.
+
+## Launching the Merge Workflow
+
+1. Navigate to the model’s changelist in the admin.
+2. Select at least two records that represent duplicates.
+3. Choose **Merge selected records** from the actions drop-down and submit the form.
+4. Review the merge form. The target record appears on the left and the source on the right. Adjust the **Strategy** column for each field if necessary and provide manual values when prompted by the *User Prompt* strategy.
+5. Submit the form to execute the merge. A success message confirms the source data moved into the target and includes the number of fields updated.
+
+Behind the scenes the merge engine reassigns relations, archives the source snapshot, deletes the source record, and records the result in `MergeLog`. Refer to `app/cms/tests/test_admin_merge.py` and `app/cms/tests/test_merge_engine.py` for concrete examples of the full workflow.
+
+## Configuring Strategies
+
+Merge strategies determine how conflicting field values resolve:
+
+- **Last Write Wins** – Always favour the source value.
+- **Prefer Non Null** – Keep the first non-empty value (source first by default).
+- **Concatenate Text** – Combine string content with a delimiter.
+- **User Prompt / Custom** – Require a manual value or callback.
+
+You can set default strategies on the model via the `merge_fields` mapping or override them per merge through the form. Relation handling follows the `relation_strategies` map defined on `MergeMixin` subclasses.
+
+For more dynamic configuration register defaults in code:
+
+```python
+from cms.merge.constants import MergeStrategy
+from cms.merge.registry import register_merge_rules
+
+register_merge_rules(
+    MyModel,
+    fields={
+        "display_name": MergeStrategy.LAST_WRITE,
+        "email": MergeStrategy.PREFER_NON_NULL,
+    },
+    relations={
+        "memberships": "merge",
+    },
+)
+```
+
+This pattern ensures the admin form and background merges use consistent defaults. See the tests mentioned above for additional registry usage examples.
+
+## Fuzzy Candidate Search
+
+The **Find merge candidates** screen provides a fuzzy search powered by the same registry. Pick a registered model, supply a query, and optionally adjust the similarity threshold. Results include the similarity score and preview fields so you can quickly assess potential duplicates.
+
+## Troubleshooting
+
+- **Action missing** – Confirm the user has the `can_merge` permission and that the model admin inherits from `MergeAdminMixin`.
+- **Forbidden JSON response** – The candidate search endpoint requires authenticated staff users; log in via the admin first.
+- **Unexpected strategy outcomes** – Review the strategy log stored on the matching `MergeLog` entry and cross-reference automated coverage in `app/cms/tests/test_merge_engine.py`.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -2,6 +2,30 @@
 
 This guide collects conventions that keep NMK CMS consistent and maintainable.  It will grow as the team documents additional patterns and architectural decisions.
 
+## Merge Engine Integration
+
+- **Opt in with `MergeMixin`**: Inherit from `cms.merge.mixins.MergeMixin` on models that can participate in merges. Override `merge_fields` to define default strategies per field and `relation_strategies` when relations require bespoke handling (for example forcing a skip or custom callback).
+- **Archive sources thoughtfully**: Provide an `archive_source_instance` implementation when the source record must be preserved. Serialise the source (for example via `cms.merge.serializers.serialize_instance`) before soft-deleting or exporting to an audit table so administrators can recover data if required.
+- **Register defaults**: Use the merge registry to centralise configuration shared across admin workflows and programmatic merges:
+
+  ```python
+  from cms.merge.constants import MergeStrategy
+  from cms.merge.registry import register_merge_rules
+
+  register_merge_rules(
+      MyModel,
+      fields={
+          "title": MergeStrategy.LAST_WRITE,
+          "description": MergeStrategy.PREFER_NON_NULL,
+      },
+      relations={
+          "members": "merge",
+      },
+  )
+  ```
+
+- **Review automated coverage**: The new integration tests in `app/cms/tests/test_merge_engine.py`, `app/cms/tests/test_admin_merge.py`, and `app/cms/tests/test_merge_fuzzy_search.py` illustrate end-to-end expectations for field resolution, admin workflows, and the fuzzy candidate endpoint. Use them as templates when extending the engine to additional models.
+
 ## Page Patterns
 
 ### List Pages


### PR DESCRIPTION
## Summary
- add integration coverage for merge_records including relation handling, logging, and archiving
- exercise the admin merge flow and fuzzy candidate API to confirm permission enforcement and strategy submission
- document the merge tool for administrators and extend developer guidance for MergeMixin usage

## Testing
- `python app/manage.py test cms.tests.test_admin_merge cms.tests.test_merge_engine cms.tests.test_merge_fuzzy_search`


------
https://chatgpt.com/codex/tasks/task_e_68e6534e79148329a85a62bb16edc827