### PR TITLE
Register merge models and stabilise merge candidate search

### DIFF
--- a/app/cms/apps.py
+++ b/app/cms/apps.py
@@ -6,3 +6,16 @@ class CmsConfig(AppConfig):
 
     def ready(self):
         import cms.signals  # 👈 this connects your signals
+        self._register_merge_models()
+
+    def _register_merge_models(self) -> None:
+        """Ensure merge-enabled models are available to the registry."""
+
+        try:
+            from cms.merge import register_merge_rules
+            from cms.models import FieldSlip, Reference, Storage
+        except ImportError:  # pragma: no cover - defensive import guard
+            return
+
+        for model in (FieldSlip, Storage, Reference):
+            register_merge_rules(model)

--- a/app/cms/static/js/merge.js
+++ b/app/cms/static/js/merge.js
@@ -250,7 +250,7 @@
     }
     clearError();
     setStatus('Searching for candidates…', 'info');
-    const url = searchForm.dataset.searchUrl;
+    const url = (searchForm.dataset.searchUrl || searchForm.getAttribute('action') || '').trim();
     if (!url) {
       showError('Search endpoint is not configured.');
       return;

--- a/app/cms/templates/admin/cms/merge/candidate_list.html
+++ b/app/cms/templates/admin/cms/merge/candidate_list.html
@@ -27,7 +27,7 @@
           <code>cms.merge.registry</code> to enable the interface.</p>
       </div>
     {% else %}
-      <form class="w3-row-padding" data-merge-search-form data-search-url="{{ search_url }}">
+      <form class="w3-row-padding" data-merge-search-form data-search-url="{{ search_url }}" action="{{ search_url }}" method="get">
         <div class="w3-third w3-margin-bottom">
           <label class="w3-text-grey" for="id_merge_model">Model</label>
           <select class="w3-select" name="model_label" id="id_merge_model" required>

--- a/app/cms/tests/test_app_config.py
+++ b/app/cms/tests/test_app_config.py
@@ -1,0 +1,27 @@
+from django.apps import apps
+from django.test import TestCase, override_settings
+
+from cms.merge import MERGE_REGISTRY
+from cms.models import FieldSlip, Reference, Storage
+
+
+@override_settings(MERGE_TOOL_FEATURE=True)
+class MergeRegistryRegistrationTests(TestCase):
+    def setUp(self):
+        self.app_config = apps.get_app_config("cms")
+        self._previous_entries = {}
+        for model in (FieldSlip, Storage, Reference):
+            if model in MERGE_REGISTRY:
+                self._previous_entries[model] = MERGE_REGISTRY[model]
+                MERGE_REGISTRY.pop(model)
+
+    def tearDown(self):
+        for model in (FieldSlip, Storage, Reference):
+            MERGE_REGISTRY.pop(model, None)
+            if model in self._previous_entries:
+                MERGE_REGISTRY[model] = self._previous_entries[model]
+
+    def test_ready_registers_default_merge_models(self):
+        self.app_config._register_merge_models()
+        for model in (FieldSlip, Storage, Reference):
+            self.assertIn(model, MERGE_REGISTRY)

--- a/docs/admin/merge-tool.md
+++ b/docs/admin/merge-tool.md
@@ -8,6 +8,12 @@ The merge tool lets authorised staff review duplicate records side-by-side and c
 2. Grant the **`can_merge`** permission for the model to the groups or users that should initiate merges. Users without the permission will not see the action and will be redirected back to the changelist if they attempt to access merge URLs.
 3. Users must be marked as staff members to access the admin and the merge candidate search endpoint.
 
+## Accessing the merge tools
+
+- **Admin merge form** – open any merge-enabled model's changelist, select the duplicate rows, and choose **Merge selected records** from the actions menu. This launches the compare-and-confirm screen at `.../admin/<app>/<model>/<id>/merge/`.
+- **Fuzzy candidate search** – visit `/merge/` while logged in as a staff user to open the dedicated search UI. The form lists every model registered with `MERGE_REGISTRY` and sends requests to `/merge/search/` to return scored candidates.
+- Both entry points honour the `MERGE_TOOL_FEATURE` flag: when disabled the URLs remain hidden and the templates render a clear *feature disabled* notice.
+
 ## Feature Flag Rollout and Safeguards
 
 The merge tooling is disabled by default and is controlled through the `ENABLE_ADMIN_MERGE` environment variable (surfaceable as `settings.MERGE_TOOL_FEATURE`).


### PR DESCRIPTION
## Summary
- register the FieldSlip, Storage, and Reference models with the merge registry during app start-up
- allow the merge candidate search form to fall back to its action URL so it continues to work if data attributes are missing
- document where staff can access the merge tooling and cover the registration hook with a regression test

## Testing
- ENABLE_ADMIN_MERGE=1 python app/manage.py test cms.tests.test_app_config cms.tests.test_merge_fuzzy_search

------
https://chatgpt.com/codex/tasks/task_e_68e66559a828832982f7ae2b6c0c9a6e