### PR TITLE
Adjust QC summary layout and surface field slip preview

### DIFF
--- a/app/cms/templates/cms/partials/accession_preview_panel.html
+++ b/app/cms/templates/cms/partials/accession_preview_panel.html
@@ -190,6 +190,82 @@
 
     <hr class="accession_hr">
 
+    {% if preview_mode %}
+      <style>
+        .fieldslip-meta-grid {
+          display: grid;
+          gap: 0.25rem 0.5rem;
+          grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        }
+        .fieldslip-meta-grid strong {
+          font-weight: 600;
+        }
+      </style>
+      <table>
+        <caption><b><u>Field Slips</u></b></caption>
+        <thead>
+          <tr>
+            <th>Field Number</th>
+            <th>Verbatim Locality</th>
+            <th>Verbatim Taxon</th>
+            <th>Verbatim Element</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if fieldslips %}
+            {% for slip in fieldslips %}
+              <tr>
+                <td>{{ slip.field_number|default:"—" }}</td>
+                <td>{{ slip.verbatim_locality|default:"—" }}</td>
+                <td>{{ slip.verbatim_taxon|default:"—" }}</td>
+                <td>{{ slip.verbatim_element|default:"—" }}</td>
+              </tr>
+              {% if slip.horizon_formation or slip.horizon_member or slip.horizon_bed or slip.horizon_chronostratigraphy or slip.verbatim_latitude or slip.verbatim_longitude or slip.verbatim_elevation or slip.aerial_photo %}
+                <tr>
+                  <td colspan="4">
+                    <small class="fieldslip-meta-grid">
+                      {% if slip.horizon_formation or slip.horizon_member or slip.horizon_bed or slip.horizon_chronostratigraphy %}
+                        <div>
+                          <strong>Verbatim horizon:</strong>
+                          <span>
+                            {% if slip.horizon_formation %}{{ slip.horizon_formation }}{% endif %}
+                            {% if slip.horizon_member %}{% if slip.horizon_formation %}, {% endif %}{{ slip.horizon_member }}{% endif %}
+                            {% if slip.horizon_bed %}{% if slip.horizon_formation or slip.horizon_member %}, {% endif %}{{ slip.horizon_bed }}{% endif %}
+                            {% if slip.horizon_chronostratigraphy %}{% if slip.horizon_formation or slip.horizon_member or slip.horizon_bed %}, {% endif %}{{ slip.horizon_chronostratigraphy }}{% endif %}
+                          </span>
+                        </div>
+                      {% endif %}
+                      {% if slip.verbatim_latitude or slip.verbatim_longitude or slip.verbatim_elevation %}
+                        <div>
+                          <strong>Coordinates:</strong>
+                          <span>
+                            {% if slip.verbatim_latitude %}Lat {{ slip.verbatim_latitude }}{% endif %}
+                            {% if slip.verbatim_longitude %}{% if slip.verbatim_latitude %}, {% endif %}Lon {{ slip.verbatim_longitude }}{% endif %}
+                            {% if slip.verbatim_elevation %}{% if slip.verbatim_latitude or slip.verbatim_longitude %}, {% endif %}Elev {{ slip.verbatim_elevation }}{% endif %}
+                          </span>
+                        </div>
+                      {% endif %}
+                      {% if slip.aerial_photo %}
+                        <div>
+                          <strong>Aerial photo:</strong> {{ slip.aerial_photo }}
+                        </div>
+                      {% endif %}
+                    </small>
+                  </td>
+                </tr>
+              {% endif %}
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="4">No Field Slips linked to this accession.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+
+      <hr class="accession_hr">
+    {% endif %}
+
     {% if not preview_mode and user.is_authenticated and user|has_group:"Collection Managers" %}
       <a href="{% url 'accession_upload_media' accession.id %}">➕ Upload Media</a>
     {% endif %}

--- a/app/cms/templates/cms/qc/wizard_base.html
+++ b/app/cms/templates/cms/qc/wizard_base.html
@@ -331,15 +331,19 @@
     }
     .qc-summary-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 1rem;
-      margin-bottom: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
     }
     .qc-summary-card {
       border: 1px solid #dcdcdc;
       border-radius: 4px;
-      padding: 0.75rem;
+      padding: 0.5rem 0.75rem;
       background-color: #f9fafc;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+      min-height: 100%;
     }
     .qc-summary-card--changed {
       border-color: #4f46e5;
@@ -348,17 +352,19 @@
     .qc-summary-label {
       font-weight: 600;
       display: block;
-      color: #555;
+      color: #4b5563;
+      font-size: 0.75rem;
+      text-transform: uppercase;
     }
     .qc-summary-value {
-      font-size: 1.5rem;
+      font-size: 1.25rem;
       font-weight: 700;
       display: block;
-      margin-top: 0.25rem;
+      margin-top: 0;
     }
     .qc-summary-delta {
-      font-size: 0.85rem;
-      color: #555;
+      font-size: 0.75rem;
+      color: #6b7280;
     }
     .qc-warning-list {
       margin: 0.5rem 0 0;
@@ -505,7 +511,7 @@
       {% if qc_preview %}
       <div class="qc-preview-panel">
         <h3 class="w3-margin-top w3-margin-bottom">Preview accession</h3>
-        {% include "cms/partials/accession_preview_panel.html" with accession=qc_preview.accession geologies=qc_preview.geologies accession_rows=qc_preview.accession_rows first_identifications=qc_preview.first_identifications identification_counts=qc_preview.identification_counts taxonomy=qc_preview.taxonomy references=qc_preview.references preview_mode=True %}
+        {% include "cms/partials/accession_preview_panel.html" with accession=qc_preview.accession geologies=qc_preview.geologies accession_rows=qc_preview.accession_rows first_identifications=qc_preview.first_identifications identification_counts=qc_preview.identification_counts taxonomy=qc_preview.taxonomy references=qc_preview.references fieldslips=qc_preview.fieldslips preview_mode=True %}
       </div>
       {% endif %}
       <div class="qc-history-panel">


### PR DESCRIPTION
## Summary
- tighten the QC summary card styling so the key accession counts take up less space
- build preview field slip objects and render related field slips in the preview accession panel for QC users

## Testing
- python app/manage.py test cms.tests --verbosity 1

------
https://chatgpt.com/codex/tasks/task_e_68e79dc858288329b544faf829008410