### PR TITLE
Add accession links to reference detail list

### DIFF
--- a/app/cms/templates/cms/reference_detail.html
+++ b/app/cms/templates/cms/reference_detail.html
@@ -51,6 +51,7 @@
                         <caption class="w3-large"><strong>Accession details</strong></caption>
                         <thead>
                             <tr>
+                                <th>Accession</th>
                                 <th>Collection</th>
                                 <th>Specimen Prefix</th>
                                 <th>Specimen Number</th>
@@ -65,6 +66,9 @@
                         <tbody>
                             {% for accession, page in accession_entries %}
                             <tr>
+                                <td>
+                                    <a href="{% url 'accession_detail' accession.pk %}">{{ accession }}</a>
+                                </td>
                                 <td>{{ accession.collection.abbreviation }}</td>
                                 <td>{{ accession.specimen_prefix.abbreviation }}</td>
                                 <td><a href="{% url 'accession_detail' accession.pk %}">{{ accession.specimen_no }}</a></td>
@@ -89,7 +93,7 @@
                             </tr>
                             {% empty %}
                             <tr>
-                                <td colspan="{% if user.is_superuser or user|has_group:"Collection Managers" %}7{% else %}6{% endif %}" class="w3-center">No accessions found.</td>
+                                <td colspan="{% if user.is_superuser or user|has_group:"Collection Managers" %}8{% else %}7{% endif %}" class="w3-center">No accessions found.</td>
                             </tr>
                             {% endfor %}
                         </tbody>


### PR DESCRIPTION
## Summary
- add an Accession column to the reference detail table
- link each accession entry to its detail view for easier navigation

## Testing
- not run (template-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ecfcae544c8329831d2bc38cb2b104