### PR TITLE
Document CMS template dependencies for upcoming refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Document CMS template context dependencies and authentication coverage in `docs/dev/frontend-guidelines.md` (T1).

--- a/app/cms/views.py
+++ b/app/cms/views.py
@@ -1,3 +1,9 @@
+"""CMS view logic.
+
+Template context inventory and authentication coverage are catalogued in
+``docs/dev/frontend-guidelines.md`` to aid upcoming template refactors.
+"""
+
 import copy
 import csv
 import json


### PR DESCRIPTION
## Summary
- catalog context, block usage, and authentication guardrails for every CMS template in the frontend guidelines
- add a module docstring in cms.views linking to the new inventory and record the audit in the changelog

## Testing
- `pytest cms/tests -q` *(fails: AppRegistryNotReady/UploadProcessingTests alias missing in test suite setup)*

------
https://chatgpt.com/codex/tasks/task_e_68ee62b532b08329b1dd131f44acbdfc