### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/app/cms/ocr_processing.py
+++ b/app/cms/ocr_processing.py
@@ -1832,10 +1832,10 @@ def _apply_rows(
 
     if truncated_suffixes:
         logger.warning(
-            "Truncated OCR rows for accession %s to %s suffixes; skipped suffixes: %s",
+            "Truncated OCR rows for accession %s to %s suffixes; skipped suffix count: %s",
             accession.pk,
             MAX_OCR_ROWS_PER_ACCESSION,
-            ", ".join(truncated_suffixes),
+            len(truncated_suffixes),
         )
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/nmkpaleo/nmk-cms/security/code-scanning/18](https://github.com/nmkpaleo/nmk-cms/security/code-scanning/18)

General fix: do not log raw user-controlled/sensitive content. Log only safe aggregates (counts/limits/accession id) or explicitly redacted values.

Best targeted fix here (without changing functionality): in `app/cms/ocr_processing.py` within `_apply_rows` at the warning block around lines 1833–1839, replace `", ".join(truncated_suffixes)` with a non-sensitive summary such as `len(truncated_suffixes)`. This preserves the warning’s purpose (rows were truncated) while removing clear-text leaked values. No import changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
