### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/app/cms/ocr_processing.py
+++ b/app/cms/ocr_processing.py
@@ -1804,9 +1804,8 @@ def _apply_rows(
             nature["element_name"] = resolved_name
             if resolved_element is None:
                 logger.warning(
-                    "Skipped nature for accession %s (suffix %s) due to missing element '[REDACTED]' and no placeholder",
+                    "Skipped nature for accession %s (suffix [REDACTED]) due to missing element '[REDACTED]' and no placeholder",
                     accession.pk,
-                    suffix,
                     # resolved_name intentionally omitted to avoid logging potentially sensitive data.
                 )
                 continue


### PR DESCRIPTION
Potential fix for [https://github.com/nmkpaleo/nmk-cms/security/code-scanning/24](https://github.com/nmkpaleo/nmk-cms/security/code-scanning/24)

To fix this without changing functionality, stop logging the raw `suffix` value and log only non-sensitive context (e.g., accession id) plus a redacted placeholder.

Best single fix: update the warning message in `app/cms/ocr_processing.py` around lines 1806–1811 so it no longer includes `%s` for suffix or passes `suffix` as an argument. Keep the warning semantics unchanged (nature skipped due to missing element and no placeholder), but redact suffix in the message text.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
