### PR TITLE
[codex] Fix merge cancel redirect validation

### DIFF
--- a/app/cms/merge/views.py
+++ b/app/cms/merge/views.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import logging
 from typing import Iterable, Mapping
-from urllib.parse import urlencode
 
 from django.apps import apps
 from django.conf import settings
@@ -31,6 +30,26 @@ from cms.merge.forms import (
 from cms.merge.mixins import MergeMixin
 from cms.merge.services import merge_elements
 from cms.models import Element, NatureOfSpecimen
+
+
+def _is_safe_cancel_url(request: HttpRequest, url: str) -> bool:
+    return url_has_allowed_host_and_scheme(
+        url=url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    )
+
+
+def _safe_cancel_url(
+    request: HttpRequest,
+    raw_url: object,
+    *,
+    fallback: str = "",
+) -> str:
+    url = str(raw_url or "").strip()
+    if url and _is_safe_cancel_url(request, url):
+        return url
+    return fallback
 
 
 class FieldSelectionMergeView(LoginRequiredMixin, View):
@@ -129,7 +148,7 @@ class FieldSelectionMergeView(LoginRequiredMixin, View):
             )
 
         cancel_url = context.get("cancel_url") or request.META.get("HTTP_REFERER", "")
-        if cancel_url and url_has_allowed_host_and_scheme(cancel_url, allowed_hosts={request.get_host()}):
+        if cancel_url and _is_safe_cancel_url(request, str(cancel_url)):
             return redirect(cancel_url)
 
         meta = target_instance._meta
@@ -192,10 +211,11 @@ class FieldSelectionMergeView(LoginRequiredMixin, View):
             data=data,
         )
 
-        cancel_url = (
+        raw_cancel_url = (
             (request.POST.get("cancel") if request.method == "POST" else request.GET.get("cancel"))
             or request.META.get("HTTP_REFERER", "")
         )
+        cancel_url = _safe_cancel_url(request, raw_cancel_url)
 
         return {
             "form": form,
@@ -344,7 +364,10 @@ class ElementMergeSelectionView(LoginRequiredMixin, PermissionRequiredMixin, Vie
             "filter": filterset,
             "page_obj": page_obj,
             "confirm_url": reverse("merge:merge_element_review"),
-            "cancel_url": request.GET.get("cancel") or request.META.get("HTTP_REFERER", ""),
+            "cancel_url": _safe_cancel_url(
+                request,
+                request.GET.get("cancel") or request.META.get("HTTP_REFERER", ""),
+            ),
         }
         return render(request, self.template_name, context)
 
@@ -371,25 +394,20 @@ class ElementMergeSelectionView(LoginRequiredMixin, PermissionRequiredMixin, Vie
             messages.error(request, _("Select valid elements to merge."))
             return redirect(reverse("merge:merge_element_selection"))
 
-        cancel_url = (request.POST.get("cancel") or request.META.get("HTTP_REFERER", "")).strip()
-        # Validate the cancel URL so that any later use as a redirect target is safe.
-        if cancel_url:
-            # Only allow URLs that point to this host and use an allowed scheme, or are relative.
-            if not url_has_allowed_host_and_scheme(
-                url=cancel_url,
-                allowed_hosts={request.get_host()},
-                require_https=request.is_secure(),
-            ):
-                cancel_url = reverse("merge:merge_element_selection")
+        cancel_url = _safe_cancel_url(
+            request,
+            request.POST.get("cancel") or request.META.get("HTTP_REFERER", ""),
+            fallback=reverse("merge:merge_element_selection"),
+        )
 
-        params = {
+        request.session["merge_element_review"] = {
             "target": target,
             "candidates": ",".join(candidate_ids),
         }
         if cancel_url:
-            params["cancel"] = cancel_url
+            request.session["merge_element_review"]["cancel"] = cancel_url
 
-        return redirect(f"{reverse('merge:merge_element_review')}?{urlencode(params)}")
+        return redirect(reverse("merge:merge_element_review"))
 
     def _build_filter(self, request: HttpRequest) -> tuple[ElementMergeFilter, Paginator.page | None]:
         queryset = Element.objects.select_related("parent_element").order_by("name", "pk")
@@ -418,8 +436,9 @@ class ElementMergeReviewView(LoginRequiredMixin, PermissionRequiredMixin, View):
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        candidates_param = request.GET.get("candidates") or ""
-        target_id = (request.GET.get("target") or "").strip()
+        review_payload = request.session.get("merge_element_review", {})
+        candidates_param = request.GET.get("candidates") or review_payload.get("candidates") or ""
+        target_id = (request.GET.get("target") or review_payload.get("target") or "").strip()
         candidate_ids = [value for value in (item.strip() for item in candidates_param.split(",")) if value]
 
         if not target_id or target_id not in candidate_ids or len(candidate_ids) < 2:
@@ -451,7 +470,11 @@ class ElementMergeReviewView(LoginRequiredMixin, PermissionRequiredMixin, View):
         )
 
         sources = [candidate.instance for candidate in candidates if candidate.role == "source"]
-        cancel_url = request.GET.get("cancel") or reverse("merge:merge_element_selection")
+        cancel_url = _safe_cancel_url(
+            request,
+            request.GET.get("cancel") or review_payload.get("cancel") or "",
+            fallback=reverse("merge:merge_element_selection"),
+        )
 
         return render(
             request,

--- a/app/cms/tests/test_element_merge_selection_views.py
+++ b/app/cms/tests/test_element_merge_selection_views.py
@@ -36,6 +36,19 @@ class ElementMergeSelectionViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Merge elements")
 
+    def test_selection_page_does_not_render_external_cancel_url(self):
+        with impersonate(self.user):
+            Element.objects.create(name="Femur")
+
+        response = self.client.get(
+            reverse("merge:merge_element_selection"),
+            {"cancel": "https://evil.example/phish"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "evil.example")
+        self.assertNotContains(response, 'name="cancel"')
+
     def test_selection_post_redirects_to_review(self):
         with impersonate(self.user):
             target = Element.objects.create(name="Target")
@@ -51,9 +64,32 @@ class ElementMergeSelectionViewTests(TestCase):
         )
 
         self.assertEqual(response.status_code, 302)
-        self.assertIn(reverse("merge:merge_element_review"), response["Location"])
-        self.assertIn(str(target.pk), response["Location"])
-        self.assertIn(str(source.pk), response["Location"])
+        self.assertEqual(response["Location"], reverse("merge:merge_element_review"))
+
+        review_payload = self.client.session["merge_element_review"]
+        self.assertEqual(review_payload["target"], str(target.pk))
+        self.assertEqual(review_payload["candidates"], f"{target.pk},{source.pk}")
+
+    def test_selection_post_does_not_propagate_external_cancel_url(self):
+        with impersonate(self.user):
+            target = Element.objects.create(name="Target")
+            source = Element.objects.create(name="Source")
+
+        response = self.client.post(
+            reverse("merge:merge_element_selection"),
+            {
+                "target": str(target.pk),
+                "source_ids": [str(source.pk)],
+                "cancel": "https://evil.example/phish",
+            },
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("merge:merge_element_review"))
+        self.assertEqual(
+            self.client.session["merge_element_review"]["cancel"],
+            reverse("merge:merge_element_selection"),
+        )
 
     def test_review_page_renders_field_selection(self):
         with impersonate(self.user):
@@ -71,3 +107,28 @@ class ElementMergeSelectionViewTests(TestCase):
         self.assertContains(response, "Review selections")
         self.assertContains(response, target.name)
         self.assertContains(response, source.name)
+
+    def test_review_page_uses_session_selection_after_post(self):
+        with impersonate(self.user):
+            target = Element.objects.create(name="Target")
+            source = Element.objects.create(name="Source")
+
+        self.client.post(
+            reverse("merge:merge_element_selection"),
+            {
+                "target": str(target.pk),
+                "source_ids": [str(source.pk)],
+                "cancel": "/admin/cms/element/",
+            },
+        )
+
+        response = self.client.get(reverse("merge:merge_element_review"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, target.name)
+        self.assertContains(response, source.name)
+        self.assertContains(
+            response,
+            '<input type="hidden" name="cancel" value="/admin/cms/element/" />',
+            html=False,
+        )

--- a/app/cms/tests/test_per_field_strategy.py
+++ b/app/cms/tests/test_per_field_strategy.py
@@ -323,6 +323,36 @@ class FieldSelectionViewMultiSourceTests(TransactionTestCase):
         self.assertEqual(response.url, "/accessions/8535/")
         merge_mock.assert_called_once()
 
+    def test_ignores_external_cancel_url_when_provided(self):
+        set_current_user(self.user)
+        target = cms_models.Storage.objects.create(area="Target")
+        source = cms_models.Storage.objects.create(area="Source")
+        set_current_user(None)
+
+        view = FieldSelectionMergeView()
+        merge_fields = view.get_mergeable_fields(cms_models.Storage)
+        data = {
+            "model": cms_models.Storage._meta.label,
+            "target": str(target.pk),
+            "candidates": ",".join([str(target.pk), str(source.pk)]),
+            "cancel": "https://evil.example/phish",
+        }
+        for field in merge_fields:
+            field_name = FieldSelectionForm.selection_field_name(field.name)
+            data.setdefault(field_name, str(target.pk))
+
+        request = self._build_request(data)
+
+        with mock.patch("cms.merge.views.merge_records") as merge_mock:
+            merge_mock.return_value = SimpleNamespace(
+                target=target, resolved_values={}, relation_actions={}
+            )
+            response = FieldSelectionMergeView.as_view()(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertNotIn("evil.example", response.url)
+        merge_mock.assert_called_once()
+
     def test_redirects_to_cancel_querystring_when_post_missing_cancel(self):
         set_current_user(self.user)
         target = cms_models.Storage.objects.create(area="Target")
@@ -379,3 +409,25 @@ class FieldSelectionViewMultiSourceTests(TransactionTestCase):
             f'<input type="hidden" name="cancel" value="{cancel_url}" />',
             html=False,
         )
+
+    @override_settings(ALLOWED_HOSTS=["testserver", "localhost"])
+    def test_does_not_render_external_cancel_hidden_input(self):
+        set_current_user(self.user)
+        target = cms_models.Storage.objects.create(area="Target")
+        source = cms_models.Storage.objects.create(area="Source")
+        set_current_user(None)
+
+        self.client.force_login(self.user)
+        response = self.client.get(
+            reverse("merge:merge_field_selection"),
+            {
+                "model": cms_models.Storage._meta.label,
+                "target": target.pk,
+                "candidates": f"{target.pk},{source.pk}",
+                "cancel": "https://evil.example/phish",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "evil.example")
+        self.assertNotContains(response, 'name="cancel"')


### PR DESCRIPTION
## Summary

Fixes CodeQL alert 36 (`py/url-redirection`) in the element merge selection flow.

The alert was caused by building a redirect URL with user-provided merge selection values in the query string. The POST handler now stores the validated review payload in the server-side session and redirects to the fixed review route instead of constructing a redirect target from request data.

## Details

- Centralized merge cancel URL validation through Django's `url_has_allowed_host_and_scheme`.
- Sanitized cancel URLs before rendering hidden inputs or Back links.
- Preserved direct review URLs that still provide `target` and `candidates` in the query string.
- Added regression coverage for external cancel URLs and the session-backed review handoff.

## Validation

- `python -m py_compile app\cms\merge\views.py app\cms\tests\test_element_merge_selection_views.py app\cms\tests\test_per_field_strategy.py`

Focused Django tests could not be completed locally because system Python is missing project dependencies (`qr_code`) and Docker Desktop is not running (`dockerDesktopLinuxEngine` pipe unavailable).